### PR TITLE
Window removal spec text

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -702,6 +702,11 @@ method must run these steps:
  <span data-anolis-spec=dom title=concept-throw>throw</span> an
  "<code data-anolis-spec=dom>InvalidStateError</code>" exception.
 
+ <li><p>If <span title=concept-XMLHttpRequest-document>document</span> is not
+ <span data-anolis-spec=html>fully active</span>,
+ <span data-anolis-spec=dom title=concept-throw>throw</span> an
+ "<code data-anolis-spec=dom>InvalidStateError</code>" exception.
+
  <li><p>If <var>header</var> does not match the
  <span data-anolis-spec=http>field-name</span> production,
  <span data-anolis-spec=dom title=concept-throw>throw</span> a


### PR DESCRIPTION
Adds explicit instructions for what happens if document is no longer fully active (for example if related IFRAME is removed or window gets closed) during a request, prescribes pass conditions for multi-window (evil) tests in test suite, for both same-origin and cross-origin cases.
