### PR TITLE
Add missing [EnsureUTF16] to FormData append()

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -2033,7 +2033,7 @@ and/or <code>XMLHttpRequestUpload</code> objects:
 [<span title="dom-FormData">Constructor</span>(optional <span data-anolis-spec=html>HTMLFormElement</span> <var>form</var>)]
 interface <dfn>FormData</dfn> {
   void <span title="dom-FormData-append">append</span>([EnsureUTF16] DOMString <var>name</var>, <span data-anolis-spec=fileapi>Blob</span> <var>value</var>, optional [EnsureUTF16] DOMString <var>filename</var>);
-  void <span title="dom-FormData-append">append</span>(DOMString <var>name</var>, [EnsureUTF16] DOMString <var>value</var>);
+  void <span title="dom-FormData-append">append</span>([EnsureUTF16] DOMString <var>name</var>, [EnsureUTF16] DOMString <var>value</var>);
   void <span title=dom-FormData-delete>delete</span>([EnsureUTF16] DOMString <var>name</var>);
   <span>FormDataEntryValue</span>? <span title=dom-FormData-get>get</span>([EnsureUTF16] DOMString <var>name</var>);
   sequence&lt;<span>FormDataEntryValue</span>> <span title=dom-FormData-getAll>getAll</span>([EnsureUTF16] DOMString <var>name</var>);


### PR DESCRIPTION
It seems an [EnsureUTF16] has been missing in one of the FormData's append() methods.
