### PR TITLE
Fix the note text of getResponseHeader()

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1424,7 +1424,7 @@ method must run these steps:
 
 <p class=note>The Cross-Origin Resource Sharing specification filters
 <span title=concept-response-header>response headers</span> exposed by
-<code title="dom-XMLHttpRequest-getAllResponseHeaders">getAllResponseHeaders()</code>
+<code title="dom-XMLHttpRequest-getAllResponseHeaders">getResponseHeader()</code>
 for <span data-anolis-spec=cors title="cross-origin request">cross-origin requests</span>.
 <span data-anolis-ref>CORS</span>
 


### PR DESCRIPTION
Fix the note text of getResponseHeader() method: "... exposed by getAllResponseHeaders() ..." to "... exposed by getResponseHeader() ..."
