### PR TITLE
One attempt at figuring out the referrer source issue

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -542,7 +542,7 @@ method must run these steps:
    <span data-anolis-spec=html>origin</span>.
 
    <li><p>Set <span>referrer source</span> to the
-   <span data-anolis-spec=html>API referrer source</span>.
+   <span data-anolis-spec=html>worker environment</span>'s <span data-anolis-spec=html>API referrer source</span>.
   </ol>
 
  <li><p>If <var>method</var> does not match the <span data-anolis-spec=http>Method</span>


### PR DESCRIPTION
1) "script's referrer source" is no longer defined in HTML it seems (certainly not in the location it was according to the xrefs). I assume "API referrer source" is the equivalent concept (although I have not found any related discussion and it's not at all clear to me why the spec distinguishes between script's responsible document and its API referrer source as it does for example in step 4 here: http://www.whatwg.org/specs/web-apps/current-work/multipage/workers.html#processing-model-7

2) In fact referrer source should always be referencing a Document when xhr.send() runs - by the algorithms over in the Worker spec and those in XHR itself - but the "API referrer source" definition says it can be a URL too, so it seems prudent to take that into account and put in ".. if it's a document, otherwise..".
