### PR TITLE
Paragraph referencing HTML spec's typographic conventions

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -192,6 +192,7 @@ certificates. Specifically it does not refer to proxy authentication or the
 <code title="http-origin">Origin</code> header.
 <span data-anolis-ref>COOKIES</span> <!-- XXX ref? -->
 
+<p>This specification uses the same typographic conventions as <span data-anolis-ref>HTML</span>.</p>
 
 
 <h2>Interface <code title>XMLHttpRequest</code></h2>


### PR DESCRIPTION
A simple change to close bug 16312..
