### PR TITLE
Allow synchronous withCredentials

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
 
 <p><a class="logo" href="https://whatwg.org/"><img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-xhr.svg" width="100"></a>
 <h1 id="xmlhttprequest-ls">XMLHttpRequest</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-19-april-2016">Living Standard — Last Updated 19 April 2016</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-25-april-2016">Living Standard — Last Updated 25 April 2016</h2>
 
 <dl>
  <dt>Participate:
@@ -489,14 +489,11 @@ unset.
   if <var title="">method</var> is a case-insensitive match for
   `<code title="">CONNECT</code>`, `<code title="">TRACE</code>` or `<code title="">TRACK</code>`.
 
-  <p>Throws an <code>InvalidAccessError</code>
-  exception if <var title="">async</var> is false,
+  <p>Throws an <code>InvalidAccessError</code> exception if <var title="">async</var> is false,
   <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry settings object</a>'s
   <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is a <a href="https://html.spec.whatwg.org/multipage/browsers.html#window"><code class="external" data-anolis-spec="html">Window</code></a>
-  object, and either the <a href="#dom-xmlhttprequest-timeout"><code title="dom-XMLHttpRequest-timeout">timeout</code></a> attribute is not
-  zero, the <a href="#dom-xmlhttprequest-withcredentials"><code title="dom-XMLHttpRequest-withCredentials">withCredentials</code></a> attribute is true,
-  or the <a href="#dom-xmlhttprequest-responsetype"><code title="dom-XMLHttpRequest-responseType">responseType</code></a> attribute is not the empty
-  string.
+  object, and the <a href="#dom-xmlhttprequest-timeout"><code title="dom-XMLHttpRequest-timeout">timeout</code></a> attribute is not zero or the
+  <a href="#dom-xmlhttprequest-responsetype"><code title="dom-XMLHttpRequest-responseType">responseType</code></a> attribute is not the empty string.
 </dl>
 
 <p class="critical no-backref" id="sync-warning">Synchronous <a href="#xmlhttprequest"><code>XMLHttpRequest</code></a>
@@ -565,10 +562,9 @@ method, when invoked, must run these steps:
 
  <li><p>If <var>async</var> is false, <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry settings object</a>'s
  <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is a <a href="https://html.spec.whatwg.org/multipage/browsers.html#window"><code class="external" data-anolis-spec="html">Window</code></a>
- object, and either the <a href="#dom-xmlhttprequest-timeout"><code title="dom-XMLHttpRequest-timeout">timeout</code></a> attribute value is not
- zero, the <a href="#dom-xmlhttprequest-withcredentials"><code title="dom-XMLHttpRequest-withCredentials">withCredentials</code></a> attribute value is
- true, or the <a href="#dom-xmlhttprequest-responsetype"><code title="dom-XMLHttpRequest-responseType">responseType</code></a> attribute value is not
- the empty string, <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#dfn-throw" title="throw">throw</a> an
+ object, and the <a href="#dom-xmlhttprequest-timeout"><code title="dom-XMLHttpRequest-timeout">timeout</code></a> attribute value is not zero
+ or the <a href="#dom-xmlhttprequest-responsetype"><code title="dom-XMLHttpRequest-responseType">responseType</code></a> attribute value is not the
+ empty string, then <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#dfn-throw" title="throw">throw</a> an
  <code>InvalidAccessError</code> exception.
 
  <li>
@@ -746,11 +742,6 @@ of <a class="external" data-anolis-spec="fetch" href="https://fetch.spec.whatwg.
   <code>InvalidStateError</code> exception if
   <a href="#concept-xmlhttprequest-state" title="concept-XMLHttpRequest-state">state</a> is not <i title="">unsent</i> or
   <i title="">opened</i>, or if the <a href="#send-flag"><code>send()</code> flag</a> is set.
-  <p>When set: throws an <code>InvalidAccessError</code> exception if the
-  <a href="#synchronous-flag">synchronous flag</a> is set and
-  <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry settings object</a>'s
-  <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is a <a href="https://html.spec.whatwg.org/multipage/browsers.html#window"><code class="external" data-anolis-spec="html">Window</code></a>
-  object.
  </dd>
 </dl>
 
@@ -771,12 +762,6 @@ attribute must run these steps:
  <li><p>If the <a href="#send-flag"><code>send()</code> flag</a> is set,
  <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#dfn-throw" title="throw">throw</a> an
  <code>InvalidStateError</code> exception.
-
- <li><p>If <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry settings object</a>'s
- <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> is a <a href="https://html.spec.whatwg.org/multipage/browsers.html#window"><code class="external" data-anolis-spec="html">Window</code></a>
- object and the <a href="#synchronous-flag">synchronous flag</a> is set,
- <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#dfn-throw" title="throw">throw</a> an
- <code>InvalidAccessError</code> exception.
 
  <li><p>Set the <a href="#dom-xmlhttprequest-withcredentials"><code title="dom-XMLHttpRequest-withCredentials">withCredentials</code></a>
  attribute's value to the given value.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -441,14 +441,11 @@ unset.
   if <var title>method</var> is a case-insensitive match for
   `<code title>CONNECT</code>`, `<code title>TRACE</code>` or `<code title>TRACK</code>`.
 
-  <p>Throws an <code>InvalidAccessError</code>
-  exception if <var title>async</var> is false,
+  <p>Throws an <code>InvalidAccessError</code> exception if <var title>async</var> is false,
   <span data-anolis-spec=html>entry settings object</span>'s
   <span data-anolis-spec=html>global object</span> is a <code data-anolis-spec=html>Window</code>
-  object, and either the <code title=dom-XMLHttpRequest-timeout>timeout</code> attribute is not
-  zero, the <code title=dom-XMLHttpRequest-withCredentials>withCredentials</code> attribute is true,
-  or the <code title=dom-XMLHttpRequest-responseType>responseType</code> attribute is not the empty
-  string.
+  object, and the <code title=dom-XMLHttpRequest-timeout>timeout</code> attribute is not zero or the
+  <code title=dom-XMLHttpRequest-responseType>responseType</code> attribute is not the empty string.
 </dl>
 
 <p class="critical no-backref" id=sync-warning>Synchronous <code>XMLHttpRequest</code>
@@ -517,10 +514,9 @@ method, when invoked, must run these steps:
 
  <li><p>If <var>async</var> is false, <span data-anolis-spec=html>entry settings object</span>'s
  <span data-anolis-spec=html>global object</span> is a <code data-anolis-spec=html>Window</code>
- object, and either the <code title=dom-XMLHttpRequest-timeout>timeout</code> attribute value is not
- zero, the <code title=dom-XMLHttpRequest-withCredentials>withCredentials</code> attribute value is
- true, or the <code title=dom-XMLHttpRequest-responseType>responseType</code> attribute value is not
- the empty string, <span data-anolis-spec=webidl title=throw>throw</span> an
+ object, and the <code title=dom-XMLHttpRequest-timeout>timeout</code> attribute value is not zero
+ or the <code title=dom-XMLHttpRequest-responseType>responseType</code> attribute value is not the
+ empty string, then <span data-anolis-spec=webidl title=throw>throw</span> an
  <code>InvalidAccessError</code> exception.
 
  <li>
@@ -698,11 +694,6 @@ of <span data-anolis-spec=fetch title=concept-fetch>fetching</span>.
   <code>InvalidStateError</code> exception if
   <span title=concept-XMLHttpRequest-state>state</span> is not <i title>unsent</i> or
   <i title>opened</i>, or if the <span><code>send()</code> flag</span> is set.
-  <p>When set: throws an <code>InvalidAccessError</code> exception if the
-  <span>synchronous flag</span> is set and
-  <span data-anolis-spec=html>entry settings object</span>'s
-  <span data-anolis-spec=html>global object</span> is a <code data-anolis-spec=html>Window</code>
-  object.
  </dd>
 </dl>
 
@@ -723,12 +714,6 @@ attribute must run these steps:
  <li><p>If the <span><code>send()</code> flag</span> is set,
  <span data-anolis-spec=webidl title=throw>throw</span> an
  <code>InvalidStateError</code> exception.
-
- <li><p>If <span data-anolis-spec=html>entry settings object</span>'s
- <span data-anolis-spec=html>global object</span> is a <code data-anolis-spec=html>Window</code>
- object and the <span>synchronous flag</span> is set,
- <span data-anolis-spec=webidl title=throw>throw</span> an
- <code>InvalidAccessError</code> exception.
 
  <li><p>Set the <code title="dom-XMLHttpRequest-withCredentials">withCredentials</code>
  attribute's value to the given value.


### PR DESCRIPTION
Unfortunately all browsers but Firefox failed to implement the
standard. This does not change the fact that synchronous XMLHttpRequest
is deprecated.

Fixes #66.