### PR TITLE
Editorial: add an IDL index

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_size = 1
+indent_style = space
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[Makefile]
+indent_style = tab
+
+[.travis.yml]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*    text=auto
+*.bs diff=html linguist-language=HTML

--- a/xhr.bs
+++ b/xhr.bs
@@ -7,7 +7,7 @@ Status: LS
 No Editor: true
 Abstract: The XMLHttpRequest Standard defines an API that provides scripted client functionality for transferring data between a client and a server.
 Logo: https://resources.whatwg.org/logo-xhr.svg
-Boilerplate: omit feedback-header, omit conformance, omit index, omit idl-index
+Boilerplate: omit feedback-header, omit conformance, omit index
 !Participate: <a href=https://github.com/whatwg/xhr>GitHub whatwg/xhr</a> (<a href=https://github.com/whatwg/xhr/issues/new>file an issue</a>, <a href=https://github.com/whatwg/xhr/issues>open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=XHR&amp;resolution=---">legacy open bugs</a>)
 !Participate: <a href=https://wiki.whatwg.org/wiki/IRC>IRC: #whatwg on Freenode</a>
 !Commits: <a href=https://github.com/whatwg/xhr/commits>GitHub whatwg/xhr/commits</a>

--- a/xhr.bs
+++ b/xhr.bs
@@ -7,7 +7,7 @@ Status: LS
 No Editor: true
 Abstract: The XMLHttpRequest Standard defines an API that provides scripted client functionality for transferring data between a client and a server.
 Logo: https://resources.whatwg.org/logo-xhr.svg
-Boilerplate: omit feedback-header, omit conformance, omit index
+Boilerplate: omit feedback-header, omit conformance
 !Participate: <a href=https://github.com/whatwg/xhr>GitHub whatwg/xhr</a> (<a href=https://github.com/whatwg/xhr/issues/new>file an issue</a>, <a href=https://github.com/whatwg/xhr/issues>open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=XHR&amp;resolution=---">legacy open bugs</a>)
 !Participate: <a href=https://wiki.whatwg.org/wiki/IRC>IRC: #whatwg on Freenode</a>
 !Commits: <a href=https://github.com/whatwg/xhr/commits>GitHub whatwg/xhr/commits</a>


### PR DESCRIPTION
Not sure if you want to add the terms index too, but I was looking for the IDL index and noticed it was missing, so here's a drive-by fix.