### PR TITLE
Clarify when subsubsubsteps run in "process response"

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1043,6 +1043,8 @@ method must run these steps:
        <a>total bytes</a>.
       </ol>
 
+      <p class=note>These subsubsubsteps are only invoked when new bytes are transmitted.
+
       <p>When <var>read</var> is fulfilled with an object whose <code>done</code> property is true,
       run <a>handle response end-of-body</a> for <var>response</var>.
 


### PR DESCRIPTION
They only run when new bytes are transmitted.

Closes #118.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://xhr.spec.whatwg.org/branch-snapshots/annevk/subsubsubsteps/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/xhr/7fb5717..annevk/subsubsubsteps:56821b2.html)