### PR TITLE
Define MIME type extraction better

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -8,7 +8,7 @@ No Editor: true
 Abstract: The XMLHttpRequest Standard defines an API that provides scripted client functionality for transferring data between a client and a server.
 Logo: https://resources.whatwg.org/logo-xhr.svg
 Boilerplate: omit feedback-header, omit conformance
-!Participate: <a href=https://github.com/whatwg/xhr>GitHub whatwg/xhr</a> (<a href=https://github.com/whatwg/xhr/issues/new>file an issue</a>, <a href=https://github.com/whatwg/xhr/issues>open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WebAppsWG&amp;component=XHR&amp;resolution=---">legacy open bugs</a>)
+!Participate: <a href=https://github.com/whatwg/xhr>GitHub whatwg/xhr</a> (<a href=https://github.com/whatwg/xhr/issues/new>file an issue</a>, <a href=https://github.com/whatwg/xhr/issues>open issues</a>)
 !Participate: <a href=https://wiki.whatwg.org/wiki/IRC>IRC: #whatwg on Freenode</a>
 !Commits: <a href=https://github.com/whatwg/xhr/commits>GitHub whatwg/xhr/commits</a>
 !Commits: [SNAPSHOT-LINK]
@@ -1382,16 +1382,21 @@ Content-Type: text/plain; charset=utf-8</code></pre>
 
 <h4 id=response-body>Response body</h4>
 
-<p>The <dfn id=response-mime-type>response MIME type</dfn> is the
-MIME type the `<code>Content-Type</code>` header contains excluding any
-parameters and in <a>ASCII lowercase</a>, or `<code>text/xml</code>` if
-the response header can not be parsed or was omitted. The
-<dfn id=override-mime-type>override MIME type</dfn> is initially null
-and can get a value if
-<a><code>overrideMimeType()</code></a>
-is invoked. <dfn id=final-mime-type>Final MIME type</dfn> is the
-<a>override MIME type</a> unless that is null in which case it is
-the <a>response MIME type</a>.
+<p>The <dfn id=response-mime-type>response MIME type</dfn> is the result of running these steps:
+
+<ol>
+ <li><p>Let <var>mimeType</var> be the result of <a for="header list">extracting a MIME type</a>
+ from <a>response</a>'s <a for=response>header list</a>.
+
+ <li><p>If <var>mimeType</var> is the empty byte sequence, then set <var>mimeType</var> to
+ `<code>text/xml</code>`.
+
+ <li><p>Return <var>mimeType</var>.
+</ol>
+
+<p>The <dfn id=override-mime-type>override MIME type</dfn> is initially null and can get a value if
+{{overrideMimeType()}} is invoked. <dfn id=final-mime-type>Final MIME type</dfn> is the
+<a>override MIME type</a> unless that is null in which case it is the <a>response MIME type</a>.
 
 <p>The <dfn id=response-charset>response charset</dfn> is the value of
 the <code>charset</code> parameter of the `<code>Content-Type</code>` header


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=23632.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://xhr.spec.whatwg.org/branch-snapshots/annevk/content-type/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/xhr/e8ddc47...b80c10e.html)