### PR TITLE
Sort and lowercase header names in getAllResponseHeaders() example

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -57,8 +57,8 @@ urlPrefix: https://w3c.github.io/DOM-Parsing/; spec: dom-parsing
  <p>Some simple code to do something with data from an XML document
  fetched over the network:
 
- <pre>
-<code>function processData(data) {
+ <pre><code class=lang-javascript>
+function processData(data) {
   // taking care of data
 }
 
@@ -81,8 +81,8 @@ client.send();</code></pre>
 
  <p>If you just want to log a message to the server:
 
- <pre>
-<code>function log(message) {
+ <pre><code class=lang-javascript>
+function log(message) {
   var client = new XMLHttpRequest();
   client.open("POST", "/log");
   client.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
@@ -91,8 +91,8 @@ client.send();</code></pre>
 
  <p>Or if you want to check the status of a document on the server:
 
- <pre>
-<code>function fetchStatus(address) {
+ <pre><code class=lang-javascript>
+function fetchStatus(address) {
   var client = new XMLHttpRequest();
   client.onload = function() {
     // in case of network errors this might not give reliable results
@@ -612,8 +612,8 @@ method must run these steps:
  <p>Some simple code demonstrating what happens when setting the same
  header twice:
 
- <pre>
-<code>// The following script:
+ <pre><code class=lang-javascript>
+// The following script:
 var client = new XMLHttpRequest();
 client.open('GET', 'demo.cgi');
 client.setRequestHeader('X-Test', 'one');
@@ -621,7 +621,7 @@ client.setRequestHeader('X-Test', 'two');
 client.send();
 
 // …results in the following header being sent:
-X-Test: one, two</code></pre>
+// X-Test: one, two</code></pre>
 </div>
 
 
@@ -1274,8 +1274,8 @@ method must run these steps:
 
  <p>For the following script:
 
- <pre>
-<code>var client = new XMLHttpRequest();
+ <pre><code class=lang-javascript>
+var client = new XMLHttpRequest();
 client.open("GET", "unicorns-are-teh-awesome.txt", true);
 client.send();
 client.onreadystatechange = function() {
@@ -1287,8 +1287,8 @@ client.onreadystatechange = function() {
  <p>The <code>print()</code> function will get to process something
  like:
 
- <pre>
-<code>text/plain; charset=UTF-8</code></pre>
+ <pre><code>
+text/plain; charset=UTF-8</code></pre>
 </div>
 
 
@@ -1318,8 +1318,8 @@ method, when invoked, must run these steps:
 <div id=example-getresponseheaders class=example>
  <p>For the following script:
 
- <pre>
-<code>var client = new XMLHttpRequest();
+ <pre><code class=lang-javascript>
+var client = new XMLHttpRequest();
 client.open("GET", "narwhals-too.txt", true);
 client.send();
 client.onreadystatechange = function() {
@@ -1331,13 +1331,13 @@ client.onreadystatechange = function() {
  <p>The <code>print()</code> function will get to process something
  like:
 
- <pre>
-<code>Date: Sun, 24 Oct 2004 04:58:38 GMT
-Server: Apache/1.3.31 (Unix)
-Keep-Alive: timeout=15, max=99
-Connection: Keep-Alive
-Transfer-Encoding: chunked
-Content-Type: text/plain; charset=utf-8</code></pre>
+ <pre><code>
+connection: Keep-Alive
+content-type: text/plain; charset=utf-8
+date: Sun, 24 Oct 2004 04:58:38 GMT
+keep-alive: timeout=15, max=99
+server: Apache/1.3.31 (Unix)
+transfer-encoding: chunked</code></pre>
 </div>
 
 
@@ -2082,7 +2082,7 @@ otherwise. [[!FETCH]]
  display the process of
  <a for=/>fetching</a> a resource.
 
- <pre>
+ <pre><code class=lang-html>
 &lt;!DOCTYPE html>
 &lt;title>Waiting for Magical Unicorns&lt;/title>
 &lt;progress id=p>&lt;/progress>
@@ -2100,7 +2100,7 @@ otherwise. [[!FETCH]]
     progressBar.value = pe.loaded
   }
   client.send()
-&lt;/script></pre>
+&lt;/script></code></pre>
 
  <p>Fully working code would of course be more elaborate and deal with more
  scenarios, such as network errors or the end user terminating the request.


### PR DESCRIPTION
Also add highlighting for code. Fixes #136.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://xhr.spec.whatwg.org/branch-snapshots/annevk/examples/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/xhr/59c9cd9...2a2090b.html)