### PR TITLE
Add note about event listeners causing preflight

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -408,10 +408,10 @@ the row where the value in the cell in the first column is <a>context object</a>
 <p>The <a>synchronous flag</a>, <a>upload complete flag</a>, and
 <a>upload listener flag</a> are initially unset.
 
-<p class=note no-backref id=event-listeners-and-preflight>Registering one or more event listeners on
-an {{XMLHttpRequestUpload}} object will result in a <a>CORS-preflight request</a>. (That is because
-registering an event listener causes the <a>upload listener flag</a> to be set, which in turn causes
-the <a>use-CORS-preflight flag</a> to be set.)
+<p class="note no-backref" id=event-listeners-and-preflight>Registering one or more event listeners
+on an {{XMLHttpRequestUpload}} object will result in a <a>CORS-preflight request</a>. (That is
+because registering an event listener causes the <a>upload listener flag</a> to be set, which in
+turn causes the <a>use-CORS-preflight flag</a> to be set.)
 
 <hr>
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -408,11 +408,10 @@ the row where the value in the cell in the first column is <a>context object</a>
 <p>The <a>synchronous flag</a>, <a>upload complete flag</a>, and
 <a>upload listener flag</a> are initially unset.
 
-<p class=note id=event-listeners-and-preflight>Registering one or more
-event listeners on an {{XMLHttpRequestUpload}} object will trigger user
-agents to perform a <a>CORS-preflight request</a>. (That is because
-registering an event listener causes the <a>upload listener flag</a> to be
-set, which in turn causes the <a>use-CORS-preflight flag</a> to be set.)
+<p class=note no-backref id=event-listeners-and-preflight>Registering one or more event listeners on
+an {{XMLHttpRequestUpload}} object will result in a <a>CORS-preflight request</a>. (That is because
+registering an event listener causes the <a>upload listener flag</a> to be set, which in turn causes
+the <a>use-CORS-preflight flag</a> to be set.)
 
 <hr>
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -408,6 +408,12 @@ the row where the value in the cell in the first column is <a>context object</a>
 <p>The <a>synchronous flag</a>, <a>upload complete flag</a>, and
 <a>upload listener flag</a> are initially unset.
 
+<p class=note id=event-listeners-and-preflight>Registering one or more
+event listeners on an {{XMLHttpRequestUpload}} object will trigger user
+agents to perform a <a>CORS-preflight request</a>. (That is because
+registering an event listener causes the <a>upload listener flag</a> to be
+set, which in turn causes the <a>use-CORS-preflight flag</a> to be set.)
+
 <hr>
 
 <p>To <dfn>terminate the request</dfn>,


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://xhr.spec.whatwg.org/branch-snapshots/sideshowbarker/event-listeners-preflight-note/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/xhr/990a157...7f68460.html)