### PR TITLE
Reference Fetch spec for “credentials” definition

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -166,13 +166,6 @@ XML.
 
 <p>It uses the typographic conventions from HTML. [[!HTML]]
 
-<p>The term <dfn>user credentials</dfn> for the purposes of this
-specification means cookies, HTTP authentication, and TLS client certificates.
-Specifically it does not refer to proxy authentication or the
-<a http-header><code>Origin</code></a> header.
-[[!COOKIES]] <!-- XXX ref? -->
-
-
 <h2 id=interface-xmlhttprequest>Interface {{XMLHttpRequest}}</h2>
 
 <pre class=idl>
@@ -671,9 +664,8 @@ of <a for=/>fetching</a>.
 <dl class=domintro>
  <dt><code><var>client</var> . <a attribute for=XMLHttpRequest>withCredentials</a></code>
  <dd>
-  <p>True when <a>user credentials</a> are to be included in a
-  cross-origin request. False when they are to be excluded in a
-  cross-origin request and when cookies are to be ignored in its response.
+  <p>True when <a>credentials</a> are to be included in a cross-origin request. False when they are
+  to be excluded in a cross-origin request and when cookies are to be ignored in its response.
   Initially false.
 
   <p>When set: throws an


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://xhr.spec.whatwg.org/branch-snapshots/sideshowbarker/credentials-reference/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/xhr/1937a2e...cd26607.html)