### PR TITLE
Use the API URL character encoding for XMLHttpRequest

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -446,33 +446,25 @@ and
 methods, when invoked, must run these steps:
 
 <ol>
- <li><p>If <a>context object</a>'s
- <a>relevant settings object</a> has a
- <a>responsible document</a> and it is <em>not</em>
- <a>fully active</a>,
- <a>throw</a> an <code>InvalidStateError</code> exception.
+ <li><p>Let <var>settingsObject</var> be <a>context object</a>'s <a>relevant settings object</a>.
 
- <li><p>If <var>method</var> is not a
- <a for=/>method</a>,
- <a>throw</a> a
- <code>SyntaxError</code> exception.
+ <li><p>If <var>settingsObject</var> has a <a>responsible document</a> and it is <em>not</em>
+ <a>fully active</a>, then <a>throw</a> an "{{InvalidStateError!!exception}}" {{DOMException}}.
 
- <li><p>If <var>method</var> is a <a>forbidden method</a>,
- <a>throw</a> a
- <code>SecurityError</code> exception.
+ <li><p>If <var>method</var> is not a <a for=/>method</a>, then <a>throw</a> a
+ "{{SyntaxError!!exception}}" {{DOMException}}.
 
- <li><p><a for=method>Normalize</a>
- <var>method</var>.
+ <li><p>If <var>method</var> is a <a>forbidden method</a>, then <a>throw</a> a
+ "{{SecurityError!!exception}}" {{DOMException}}.
 
- <li><p>Let <var>parsedURL</var> be the result of
- <a lt="URL parser">parsing</a> <var>url</var> with
- <a>context object</a>'s
- <a>relevant settings object</a>'s
- <a>API base URL</a>.
+ <li><p><a for=method>Normalize</a> <var>method</var>.
 
- <li><p>If <var>parsedURL</var> is failure,
- <a>throw</a> a
- <code>SyntaxError</code> exception.
+ <li><p>Let <var>parsedURL</var> be the result of <a lt="URL parser">parsing</a> <var>url</var> with
+ <var>settingsObject</var>'s <a for="environment settings object">API base URL</a> and
+ <var>settingsObject</var>'s <a for="environment settings object">API URL character encoding</a>.
+
+ <li><p>If <var>parsedURL</var> is failure, then <a>throw</a> a "{{SyntaxError!!exception}}"
+ {{DOMException}}.
 
  <li>
   <p>If the <var>async</var> argument is omitted, set <var>async</var> to true, and set
@@ -495,11 +487,10 @@ methods, when invoked, must run these steps:
    <var>password</var>.
   </ol>
 
- <li><p>If <var>async</var> is false, <a>current global object</a> is a {{Window}}
- object, and the {{XMLHttpRequest/timeout!!attribute}} attribute value is not zero
- or the {{XMLHttpRequest/responseType}} attribute value is not the
- empty string, then <a>throw</a> an
- <code>InvalidAccessError</code> exception.
+ <li><p>If <var>async</var> is false, <a>current global object</a> is a {{Window}} object, and the
+ {{XMLHttpRequest/timeout!!attribute}} attribute value is not zero or the
+ {{XMLHttpRequest/responseType}} attribute value is not the empty string, then <a>throw</a> an
+ "{{InvalidAccessError!!exception}}" {{DOMException}}.
 
  <li>
   <p><a for=fetch lt=terminated>Terminate</a> the ongoing fetch operated by the


### PR DESCRIPTION
Unfortunately forcing UTF-8 is not web compatible.

This also cleans up some other steps in the open() method in the process.

Tests: https://hg.mozilla.org/releases/mozilla-beta/rev/fd6134823ff9.

Fixes #159.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/172.html" title="Last updated on Dec 4, 2017, 1:18 PM GMT (6ee39d9)">Preview</a> | <a href="https://whatpr.org/xhr/172/900f013...6ee39d9.html" title="Last updated on Dec 4, 2017, 1:18 PM GMT (6ee39d9)">Diff</a>