### PR TITLE
Fix overrideMimeType() again

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1307,13 +1307,21 @@ when {{overrideMimeType()}} is invoked. <dfn id=final-mime-type>Final MIME type<
 <p><dfn id=final-charset>Final charset</dfn> is the return value of these steps:
 
 <ol>
- <li><p>If <a>override MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"] is
- not nothing, then return it.
+ <li><p>Let <var>label<var> be null.
 
- <li><p>If <a>response MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"] is
- not nothing, then return it.
+ <li><p>If <a>response MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"]
+ <a for=map>exists</a>, then set <var>label</var> to it.
 
- <li><p>Return null.
+ <li><p>If <a>override MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"]
+ <a for=map>exists</a>, then set <var>label</var> to it.
+
+ <li><p>If <var>label</var> is null, then return null.
+
+ <li><p>Let <var>encoding</var> be the result of <a>getting an encoding</a> from <var>label</var>.
+
+ <li><p>If <var>encoding</var> is failure, then return null.
+
+ <li><p>Return <var>encoding</var>.
 </ol>
 
 <p class=note>The above steps intentionally do not use <a>final MIME type</a> as it would yield the
@@ -1497,7 +1505,7 @@ when invoked, must run these steps:
  <li><p>Set <a>override MIME type</a> to the result of <a lt="parse a MIME type">parsing</a>
  <var>mime</var>.
 
- <li><p>If <a>override MIME type</a> is failure, then set <var>mimeTypeRecord</var> to a new
+ <li><p>If <a>override MIME type</a> is failure, then set <a>override MIME type</a> to a new
  <a>MIME type</a> whose <a for="MIME type">type</a> is "<code>application</code>" and
  <a for="MIME type">subtype</a> is "<code>octet-stream</code>".
 </ol>

--- a/xhr.bs
+++ b/xhr.bs
@@ -1301,13 +1301,13 @@ transfer-encoding: chunked</code></pre>
 </ol>
 
 <p>The <dfn id=override-mime-type>override MIME type</dfn> is initially null and can get a value
-when {{overrideMimeType()}} is invoked. <dfn id=final-mime-type>Final MIME type</dfn> is the
+when {{overrideMimeType()}} is invoked. The <dfn id=final-mime-type>final MIME type</dfn> is the
 <a>override MIME type</a> unless that is null in which case it is the <a>response MIME type</a>.
 
-<p><dfn id=final-charset>Final charset</dfn> is the return value of these steps:
+<p>The <dfn id=final-charset>final charset</dfn> is the return value of these steps:
 
 <ol>
- <li><p>Let <var>label<var> be null.
+ <li><p>Let <var>label</var> be null.
 
  <li><p>If <a>response MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"]
  <a for=map>exists</a>, then set <var>label</var> to it.
@@ -1324,8 +1324,8 @@ when {{overrideMimeType()}} is invoked. <dfn id=final-mime-type>Final MIME type<
  <li><p>Return <var>encoding</var>.
 </ol>
 
-<p class=note>The above steps intentionally do not use <a>final MIME type</a> as it would yield the
-wrong result.
+<p class=note>The above steps intentionally do not use the <a>final MIME type</a> as it would yield
+the wrong result.
 
 <hr>
 
@@ -1350,7 +1350,7 @@ or null). Unless stated otherwise it is null.
 
 <ol>
  <li><p>Set <a>response object</a> to a new {{Blob}} object representing <a>received bytes</a> with
- {{Blob/type}} <a>final MIME type</a>.
+ {{Blob/type}} set to the <a>final MIME type</a>.
 
  <li><p>Return <a>response object</a>.
 </ol>
@@ -1362,11 +1362,11 @@ or null). Unless stated otherwise it is null.
  <li><p>If <a>response</a>'s
  <a for=response>body</a> is null, then return null.
 
- <li><p>If <a>final MIME type</a> is not an <a>HTML MIME type</a> or an <a>XML MIME type</a>, then
- return null.
+ <li><p>If the <a>final MIME type</a> is not an <a>HTML MIME type</a> or an <a>XML MIME type</a>,
+ then return null.
 
  <li>
-  <p>If {{XMLHttpRequest/responseType}} is the empty string and <a>final MIME type</a> is an
+  <p>If {{XMLHttpRequest/responseType}} is the empty string and the <a>final MIME type</a> is an
   <a>HTML MIME type</a>, then return null.
 
   <p class=note>This is restricted to
@@ -1375,7 +1375,7 @@ or null). Unless stated otherwise it is null.
   content.
 
  <li>
-  <p>If <a>final MIME type</a> is an <a>HTML MIME type</a>, then run these substeps:
+  <p>If the <a>final MIME type</a> is an <a>HTML MIME type</a>, then:
 
   <ol>
    <li><p>Let <var>charset</var> be the <a>final charset</a>.
@@ -1420,7 +1420,7 @@ or null). Unless stated otherwise it is null.
  <a for=Document>encoding</a> to
  <var>charset</var>.
 
- <li><p>Set <var>document</var>'s <a>content type</a> to <a>final MIME type</a>.
+ <li><p>Set <var>document</var>'s <a>content type</a> to the <a>final MIME type</a>.
 
  <li><p>Set <var>document</var>'s
  <a for=Document>URL</a> to
@@ -1459,7 +1459,7 @@ or null). Unless stated otherwise it is null.
  <li><p>Let <var>charset</var> be the <a>final charset</a>.
 
  <li>
-  <p>If {{XMLHttpRequest/responseType}} is the empty string, <var>charset</var> is null, and
+  <p>If {{XMLHttpRequest/responseType}} is the empty string, <var>charset</var> is null, and the
   <a>final MIME type</a> is an <a>XML MIME type</a>, then use the rules set forth in the XML
   specifications to determine the encoding. Let <var>charset</var> be the determined encoding.
   [[!XML]] [[!XMLNS]]
@@ -1505,9 +1505,8 @@ when invoked, must run these steps:
  <li><p>Set <a>override MIME type</a> to the result of <a lt="parse a MIME type">parsing</a>
  <var>mime</var>.
 
- <li><p>If <a>override MIME type</a> is failure, then set <a>override MIME type</a> to a new
- <a>MIME type</a> whose <a for="MIME type">type</a> is "<code>application</code>" and
- <a for="MIME type">subtype</a> is "<code>octet-stream</code>".
+ <li><p>If <a>override MIME type</a> is failure, then set <a>override MIME type</a> to
+ <code>application/octet-stream</code>.
 </ol>
 
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -495,6 +495,7 @@ methods, when invoked, must run these steps:
    <a>network error</a>.
    <li><p>Set <a>received bytes</a> to the empty byte sequence.
    <li><p>Set <a>response object</a> to null.
+   <li><p>Set <a>override MIME type</a> to null.
   </ul>
 
  <li>
@@ -1299,19 +1300,24 @@ transfer-encoding: chunked</code></pre>
  <li><p>Return <var>mimeType</var>.
 </ol>
 
-<p>The <dfn id=override-mime-type>override MIME type</dfn> is initially null and can get a value if
-{{overrideMimeType()}} is invoked. <dfn id=final-mime-type>Final MIME type</dfn> is the
+<p>The <dfn id=override-mime-type>override MIME type</dfn> is initially null and can get a value
+when {{overrideMimeType()}} is invoked. <dfn id=final-mime-type>Final MIME type</dfn> is the
 <a>override MIME type</a> unless that is null in which case it is the <a>response MIME type</a>.
 
-<p>The <dfn id=response-charset>response charset</dfn> is the value of
-the <code>charset</code> parameter of the `<code>Content-Type</code>` header
-or null if there was no `<code>charset</code>` parameter or the header could
-not be parsed or was omitted. The
-<dfn id=override-charset>override charset</dfn> is initially null and
-can get a value if <a><code>overrideMimeType()</code></a> is invoked.
-<dfn id=final-charset>Final charset</dfn> is the
-<a>override charset</a> unless
-that is null in which case it is the <a>response charset</a>.
+<p><dfn id=final-charset>Final charset</dfn> is the return value of these steps:
+
+<ol>
+ <li><p>If <a>override MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"] is
+ not nothing, then return it.
+
+ <li><p>If <a>response MIME type</a>'s <a for="MIME type">parameters</a>["<code>charset</code>"] is
+ not nothing, then return it.
+
+ <li><p>Return null.
+</ol>
+
+<p class=note>The above steps intentionally do not use <a>final MIME type</a> as it would yield the
+wrong result.
 
 <hr>
 
@@ -1474,28 +1480,26 @@ resources using <a>utf-8</a>.
 <dl class=domintro>
  <dt><code><var>client</var> . <a method for=XMLHttpRequest>overrideMimeType(<var>mime</var>)</a></code>
  <dd>
-  <p>Acts as if the `<code>Content-Type</code>` header for <a>response</a> is <var>mime</var>.
+  <p>Acts as if the `<code>Content-Type</code>` header value for <a>response</a> is <var>mime</var>.
+  (It does not actually change the header though.)
 
   <p>Throws an "{{InvalidStateError!!exception}}" {{DOMException}} if <a>state</a> is <i>loading</i>
   or <i>done</i>.
 </dl>
 
-<p>The
-<dfn method for=XMLHttpRequest><code>overrideMimeType(<var>mime</var>)</code></dfn>
-method must run these steps:
+<p>The <dfn method for=XMLHttpRequest><code>overrideMimeType(<var>mime</var>)</code></dfn> method,
+when invoked, must run these steps:
 
 <ol>
  <li><p>If <a>state</a> is <i>loading</i> or <i>done</i>, then <a>throw</a> an
  "{{InvalidStateError!!exception}}" {{DOMException}}.
 
- <li><p>Set <a>override MIME type</a> to `<code>application/octet-stream</code>`.
+ <li><p>Set <a>override MIME type</a> to the result of <a lt="parse a MIME type">parsing</a>
+ <var>mime</var>.
 
- <li><p>If <var>mime</var> is a <a>parsable MIME type</a>, then set <a>override MIME type</a> to its
- <a>MIME type portion</a>.
- <!-- XXX Ignore string to byte sequence conversion issues until some point in the future -->
-
- <li><p>If <a>override MIME type</a> has a `<code>charset</code>` parameter, then set
- <a>override charset</a> to its value.
+ <li><p>If <a>override MIME type</a> is failure, then set <var>mimeTypeRecord</var> to a new
+ <a>MIME type</a> whose <a for="MIME type">type</a> is "<code>application</code>" and
+ <a for="MIME type">subtype</a> is "<code>octet-stream</code>".
 </ol>
 
 


### PR DESCRIPTION
Reset override MIME type when open() is invoked.

Actually make overriding the charset parameter work (setting override MIME type to the "MIME type portion" (now essence) as done previously would always erase it.

Tests: https://github.com/w3c/web-platform-tests/pull/8449.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/174.html" title="Last updated on Apr 16, 2018, 9:55 AM GMT (80dcbba)">Preview</a> | <a href="https://whatpr.org/xhr/174/edc6f8f...80dcbba.html" title="Last updated on Apr 16, 2018, 9:55 AM GMT (80dcbba)">Diff</a>