### PR TITLE
Define Content-Type manipulation in terms of MIME Sniffing

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -761,17 +761,31 @@ method must run these steps:
   <a for="header list">append</a> `<code>Content-Type</code>`/<var>mimeType</var> to
   <a>author request headers</a>.
 
-  <p>Otherwise, if the <a>header</a> whose <a for=header>name</a> is a <a>byte-case-insensitive</a>
-  match for `<code>Content-Type</code>` in <a>author request headers</a> has a
-  <a for=header>value</a> that is a <a>valid MIME type</a>, which has a `<code>charset</code>`
-  parameter whose value is not a <a>byte-case-insensitive</a> match for <var>encoding</var>, and
-  <var>encoding</var> is not null, then set all the `<code>charset</code>` parameters whose value is
-  not a <a>byte-case-insensitive</a> match for <var>encoding</var> of that <a>header</a>'s
-  <a for=header>value</a> to <var>encoding</var>.
-  <!-- XXX could still be better with parameter cross-ref -->
+  <p>Otherwise, if <var>encoding</var> is non-null, run these steps:
 
-  <!-- reminder: if we ever change this to always include charset it has
-  to be included as the first parameter for compatibility reasons -->
+  <ol>
+   <li><p>Let <var>value</var> be the <a for=header>value</a> of the <a>header</a> whose
+   <a for=header>name</a> is a <a>byte-case-insensitive</a> match for `<code>Content-Type</code>` in
+   <a>author request headers</a>.
+
+   <li><p>Let <var>mimeTypeRecord</var> be <var>value</var>,
+   <a for="parse a MIME type from bytes">parsed</a>.
+
+   <li>
+    <p>If <var>mimeTypeRecord</var> is not failure and
+    <var>mimeTypeRecord</var>["<code>charset</code>"] is not nothing, then:
+
+    <ol>
+     <li><p><a for=map>Set</a> <var>mimeTypeRecord</var>["<code>charset</code>"] to
+     <var>encoding</var>.
+
+     <li><p>Let <var>newValue</var> be <var>mimeTypeRecord</var>,
+     <a for="serialize a MIME type with bytes">serialized</a>.
+
+     <li><p><a for="header list">Set</a> `<code>Content-Type</code>`/<var>newValue</var> in
+     <a>author request headers</a>.
+    </ol>
+  </ol>
 
  <li><p>If one or more event listeners are registered on the associated
  {{XMLHttpRequestUpload}} object, then set <a>upload listener flag</a>.

--- a/xhr.bs
+++ b/xhr.bs
@@ -771,7 +771,7 @@ method must run these steps:
    <!-- XXX: add a primitive for this in Fetch -->
 
    <li><p>Let <var>mimeTypeRecord</var> be <var>value</var>,
-   <a for="parse a MIME type from bytes">parsed</a>.
+   <a lt="parse a MIME type from bytes">parsed</a>.
 
    <li>
     <p>If <var>mimeTypeRecord</var> is not failure and
@@ -783,7 +783,7 @@ method must run these steps:
      <a for="MIME type">parameters</a>["<code>charset</code>"] to <var>encoding</var>.
 
      <li><p>Let <var>newValue</var> be <var>mimeTypeRecord</var>,
-     <a for="serialize a MIME type with bytes">serialized</a>.
+     <a lt="serialize a MIME type with bytes">serialized</a>.
 
      <li><p><a for="header list">Set</a> `<code>Content-Type</code>`/<var>newValue</var> in
      <a>author request headers</a>.

--- a/xhr.bs
+++ b/xhr.bs
@@ -761,23 +761,26 @@ method must run these steps:
   <a for="header list">append</a> `<code>Content-Type</code>`/<var>mimeType</var> to
   <a>author request headers</a>.
 
-  <p>Otherwise, if <var>encoding</var> is non-null, run these steps:
+  <p>Otherwise, if <var>encoding</var> is non-null and <a>author request headers</a>
+  <a for="header list">contains</a> `<code>Content-Type</code>`:
 
   <ol>
    <li><p>Let <var>value</var> be the <a for=header>value</a> of the <a>header</a> whose
    <a for=header>name</a> is a <a>byte-case-insensitive</a> match for `<code>Content-Type</code>` in
    <a>author request headers</a>.
+   <!-- XXX: add a primitive for this in Fetch -->
 
    <li><p>Let <var>mimeTypeRecord</var> be <var>value</var>,
    <a for="parse a MIME type from bytes">parsed</a>.
 
    <li>
     <p>If <var>mimeTypeRecord</var> is not failure and
-    <var>mimeTypeRecord</var>["<code>charset</code>"] is not nothing, then:
+    <var>mimeTypeRecord</var>'s <a for="MIME type">parameters</a>["<code>charset</code>"]
+    <a for=map>exists</a>, then:
 
     <ol>
-     <li><p><a for=map>Set</a> <var>mimeTypeRecord</var>["<code>charset</code>"] to
-     <var>encoding</var>.
+     <li><p><a for=map>Set</a> <var>mimeTypeRecord</var>'s
+     <a for="MIME type">parameters</a>["<code>charset</code>"] to <var>encoding</var>.
 
      <li><p>Let <var>newValue</var> be <var>mimeTypeRecord</var>,
      <a for="serialize a MIME type with bytes">serialized</a>.

--- a/xhr.bs
+++ b/xhr.bs
@@ -783,7 +783,7 @@ method must run these steps:
      <a for="MIME type">parameters</a>["<code>charset</code>"] to <var>encoding</var>.
 
      <li><p>Let <var>newValue</var> be <var>mimeTypeRecord</var>,
-     <a lt="serialize a MIME type with bytes">serialized</a>.
+     <a lt="serialize a MIME type to bytes">serialized</a>.
 
      <li><p><a for="header list">Set</a> `<code>Content-Type</code>`/<var>newValue</var> in
      <a>author request headers</a>.


### PR DESCRIPTION
Note that this also replaces "utf-8" with "UTF-8" and no longer preserves duplicate parameters.

Tests: https://github.com/w3c/web-platform-tests/pull/8422.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/176.html" title="Last updated on Apr 10, 2018, 2:56 PM GMT (a85a8e9)">Preview</a> | <a href="https://whatpr.org/xhr/176/c6583e9...a85a8e9.html" title="Last updated on Apr 10, 2018, 2:56 PM GMT (a85a8e9)">Diff</a>