### PR TITLE
Meta: remove mention of CC0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see the [contributor guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).
+Please see the [WHATWG Contributor Guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you want to do a complete "local deploy" including commit and/or branch snaps
 ### Merge policy
 
 If you can commit to this repository, see the
-[maintainer guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
+[WHATWG Maintainer Guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
 
 ### Tests
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -2052,9 +2052,6 @@ otherwise. [[!FETCH]]
 </div>
 
 
-<div data-fill-with=references></div>
-
-
 <h2 class=no-num id=acknowledgments>Acknowledgments</h2>
 
 <p>Thanks to
@@ -2175,7 +2172,3 @@ the HTML Standard (then Web Applications 1.0). [[!HTML]]
 <a href=https://annevankesteren.nl/ lang=nl>Anne van Kesteren</a>
 (<a href=https://www.mozilla.org/>Mozilla</a>,
 <a href=mailto:annevk@annevk.nl>annevk@annevk.nl</a>).
-
-<p>Per <a rel=license href=https://creativecommons.org/publicdomain/zero/1.0/>CC0</a>, to
-the extent possible under law, the editor has waived all copyright and related or
-neighboring rights to this work.


### PR DESCRIPTION
Also fix a couple other nits.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/187.html" title="Last updated on Jan 12, 2018, 8:59 PM GMT (d62a11f)">Preview</a> | <a href="https://whatpr.org/xhr/187/74415d4...d62a11f.html" title="Last updated on Jan 12, 2018, 8:59 PM GMT (d62a11f)">Diff</a>