### PR TITLE
Don't fire "progress" event for sync XHR

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1047,7 +1047,7 @@ method must run these steps:
  <li><p>Let <var>length</var> be <var>response</var>'s <a for=response>body</a>'s
  <a for=body>total bytes</a>.
 
- <li><p><a>Fire a progress event</a> named
+ <li><p>If the <a>synchronous flag</a> is unset, <a>fire a progress event</a> named
  <a event><code>progress</code></a> with <var>transmitted</var> and <var>length</var>.
 
  <li><p>Set <a>state</a> to <i>done</i>.


### PR DESCRIPTION
Only fire a "progress" event during "handle response end-of-body" for
asynchronous XHR. This matches existing browser behaviour.

Test at https://github.com/w3c/web-platform-tests/pull/10887.

Closes #207.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/208.html" title="Last updated on May 8, 2018, 10:17 AM GMT (8173703)">Preview</a> | <a href="https://whatpr.org/xhr/208/0b0dce1...8173703.html" title="Last updated on May 8, 2018, 10:17 AM GMT (8173703)">Diff</a>