### PR TITLE
Remove outdated note from setRequestHeader()

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -529,12 +529,6 @@ the editing software used to write the XMLHttpRequest Standard.
   or if <var>value</var> is not a header value.
 </dl>
 
-<p class=note>As indicated in the algorithm below certain headers cannot
-be set and are left up to the user agent. In addition there are certain
-other headers the user agent will take control of if they are not set by
-the author as indicated at the end of the
-<a><code>send()</code></a> method section.
-
 <p>The
 <dfn id=dom-xmlhttprequest-setrequestheader method for=XMLHttpRequest><code>setRequestHeader(<var>name</var>, <var>value</var>)</code></dfn>
 method must run these steps:
@@ -2101,6 +2095,7 @@ Philip Taylor,
 Robin Berjon,
 Rune <span title=Fabulous>F.</span> Halvorsen,
 Ruud Steltenpool,
+Ryo Onodera,
 Sergiu Dumitriu,
 Shivakumar Jagalur Matt,
 Sigbjørn Finne,


### PR DESCRIPTION
A tiny and first pull request for https://github.com/whatwg/xhr/issues/213

:)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/215.html" title="Last updated on Jun 15, 2018, 7:53 AM GMT (c2f6eea)">Preview</a> | <a href="https://whatpr.org/xhr/215/9f22aa3...c2f6eea.html" title="Last updated on Jun 15, 2018, 7:53 AM GMT (c2f6eea)">Diff</a>