### PR TITLE
Do not reset override MIME type

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -672,10 +672,8 @@ object has an associated {{XMLHttpRequestUpload}} object.
 <dl class=domintro>
  <dt><code><var>client</var> . <a method for=XMLHttpRequest lt="send(body)">send([<var>body</var> = null])</a></code>
  <dd>
-  <p>Initiates the request. The optional argument provides the
-  <a>request body</a>. The argument is ignored if
-  <a>request method</a> is <code>GET</code> or
-  <code>HEAD</code>.
+  <p>Initiates the request. The <var>body</var> argument provides the <a>request body</a>, if any,
+  and is ignored if the <a>request method</a> is <code>GET</code> or <code>HEAD</code>.
 
   <p>Throws an "{{InvalidStateError!!exception}}" {{DOMException}} if either <a>state</a> is not
   <i>opened</i> or the <a><code>send()</code> flag</a> is set.

--- a/xhr.bs
+++ b/xhr.bs
@@ -494,8 +494,10 @@ methods, when invoked, must run these steps:
    <a>network error</a>.
    <li><p>Set <a>received bytes</a> to the empty byte sequence.
    <li><p>Set <a>response object</a> to null.
-   <li><p>Set <a>override MIME type</a> to null.
   </ul>
+
+  <p class=note><a>Override MIME type</a> is not overridden here as the
+  <code>overrideMimeType()</code> method can be invoked before the <code>open()</code> method.
 
  <li>
   <p>If the <a>state</a> is not


### PR DESCRIPTION
It does not make much sense as overrideMimeType() isn't blocked from being used before open() is invoked. (And 3/4 of the major implementations do not have this behavior.)

Partially reverts 121cee50b6f51215f046266642964b4c53a02a7c.

Tests: https://github.com/web-platform-tests/wpt/pull/12404.

Closes https://github.com/web-platform-tests/wpt/issues/12289.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/218.html" title="Last updated on Aug 10, 2018, 9:57 AM GMT (e288c10)">Preview</a> | <a href="https://whatpr.org/xhr/218/ce716e8...e288c10.html" title="Last updated on Aug 10, 2018, 9:57 AM GMT (e288c10)">Diff</a>