### PR TITLE
Limit Content-Type overrides to when charset isn't already UTF-8

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -723,8 +723,10 @@ method must run these steps:
        <a lt="parse a MIME type from bytes">parsing</a> <var>originalAuthorContentType</var>.
 
        <li>
-        <p>If <var>contentTypeRecord</var> is not failure, and <var>contentTypeRecord</var>'s
-        <a for="MIME type">parameters</a>["<code>charset</code>"] <a for=map>exists</a>, then:
+        <p>If <var>contentTypeRecord</var> is not failure, <var>contentTypeRecord</var>'s
+        <a for="MIME type">parameters</a>["<code>charset</code>"] <a for=map>exists</a>, and
+        <a for="MIME type">parameters</a>["<code>charset</code>"] is not an
+        <a>ASCII case-insensitive</a> match for "<code>UTF-8</code>", then:
 
         <ol>
          <li><p><a for=map>Set</a> <var>contentTypeRecord</var>'s


### PR DESCRIPTION
This will help web compatibility and address all cases linked from https://github.com/whatwg/mimesniff/issues/84.

Tests: ...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/224.html" title="Last updated on Oct 16, 2018, 1:20 PM GMT (0624970)">Preview</a> | <a href="https://whatpr.org/xhr/224/7d8526b...0624970.html" title="Last updated on Oct 16, 2018, 1:20 PM GMT (0624970)">Diff</a>