### PR TITLE
Extract a MIME type no longer returns bytes

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1291,8 +1291,7 @@ transfer-encoding: chunked</code></pre>
  <li><p>Let <var>mimeType</var> be the result of <a for="header list">extracting a MIME type</a>
  from <a>response</a>'s <a for=response>header list</a>.
 
- <li><p>If <var>mimeType</var> is the empty byte sequence, then set <var>mimeType</var> to
- `<code>text/xml</code>`.
+ <li><p>If <var>mimeType</var> is failure, then set <var>mimeType</var> to <code>text/xml</code>.
 
  <li><p>Return <var>mimeType</var>.
 </ol>


### PR DESCRIPTION
This aligns with the changes made in https://github.com/whatwg/fetch/pull/831. Fortunately the remainder of the prose already assumed it got a MIME type record rather than bytes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/227.html" title="Last updated on Nov 13, 2018, 1:04 PM GMT (18924f9)">Preview</a> | <a href="https://whatpr.org/xhr/227/721f3c9...18924f9.html" title="Last updated on Nov 13, 2018, 1:04 PM GMT (18924f9)">Diff</a>