### PR TITLE
Stop using "combined value"

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1196,24 +1196,14 @@ attribute must return the <a>response</a>'s
 
 <h4 id=the-getresponseheader()-method>The <code>getResponseHeader()</code> method</h4>
 
-<p>The
-<dfn method for=XMLHttpRequest><code>getResponseHeader(<var>name</var>)</code></dfn>
-method must run these steps:
-
-<ol>
- <li><p>If <a>response</a>'s <a for=response>header list</a>
- <a for="header list" lt=contain>does not contain</a> <var>name</var>, then return null.
-
- <li><p>Return the <a>combined value</a> given <var>name</var> and <a>response</a>'s
- <a for=response>header list</a>.
-</ol>
+<p>The <dfn method for=XMLHttpRequest><code>getResponseHeader(<var>name</var>)</code></dfn> method,
+when invoked, must return the result of <a for="header list">getting</a> <var>name</var> from
+<a>response</a>'s <a for=response>header list</a>
 
 <p class="note no-backref">The Fetch Standard filters <a>response</a>'s
-<a for=response>header list</a>.
-[[!FETCH]]
+<a for=response>header list</a>. [[!FETCH]]
 
 <div id=example-getresponseheader class=example>
-
  <p>For the following script:
 
  <pre><code class=lang-javascript>
@@ -1226,8 +1216,7 @@ client.onreadystatechange = function() {
   }
 }</code></pre>
 
- <p>The <code>print()</code> function will get to process something
- like:
+ <p>The <code>print()</code> function will get to process something like:
 
  <pre><code>
 text/plain; charset=UTF-8</code></pre>


### PR DESCRIPTION
Header list's get is much nicer.

See https://github.com/whatwg/fetch/pull/840 for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/229.html" title="Last updated on Nov 27, 2018, 2:18 PM GMT (b4e8507)">Preview</a> | <a href="https://whatpr.org/xhr/229/721f3c9...b4e8507.html" title="Last updated on Nov 27, 2018, 2:18 PM GMT (b4e8507)">Diff</a>