### PR TITLE
FormData constructor should throw if "constructing the entry list" re…

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1776,8 +1776,17 @@ constructor must run these steps:
 <ol>
  <li><p>Let <var>fd</var> be a new {{FormData}} object.
 
- <li><p>If <var>form</var> is given, then set <var>fd</var>'s <a for=FormData>entry list</a> to the
- result of <a>constructing the entry list</a> for <var>form</var>.
+ <li><p>If <var>form</var> is given, then:</p>
+
+  <ol>
+   <li><p>Let <var>list</var> be the result of <a>constructing the entry list</a> for
+   <var>form</var>.<p></li>
+
+   <li><p>If <var>list</var> is null, <a>throw</a> an "{{IllegalStateError!!exception}}"
+   {{DOMException}}.</p></li>
+
+   <li><p>Set <var>fd</var>'s <a for=FormData>entry list</a> to <var>list</var>.</p></li>
+  </ol>
 
  <li><p>Return <var>fd</var>.
 </ol>

--- a/xhr.bs
+++ b/xhr.bs
@@ -1776,16 +1776,17 @@ constructor must run these steps:
 <ol>
  <li><p>Let <var>fd</var> be a new {{FormData}} object.
 
- <li><p>If <var>form</var> is given, then:</p>
+ <li>
+  <p>If <var>form</var> is given, then:
 
   <ol>
    <li><p>Let <var>list</var> be the result of <a>constructing the entry list</a> for
-   <var>form</var>.<p></li>
+   <var>form</var>.
 
-   <li><p>If <var>list</var> is null, <a>throw</a> an "{{InvalidStateError!!exception}}"
-   {{DOMException}}.</p></li>
+   <li><p>If <var>list</var> is null, then <a>throw</a> an "{{InvalidStateError!!exception}}"
+   {{DOMException}}.
 
-   <li><p>Set <var>fd</var>'s <a for=FormData>entry list</a> to <var>list</var>.</p></li>
+   <li><p>Set <var>fd</var>'s <a for=FormData>entry list</a> to <var>list</var>.
   </ol>
 
  <li><p>Return <var>fd</var>.

--- a/xhr.bs
+++ b/xhr.bs
@@ -1782,7 +1782,7 @@ constructor must run these steps:
    <li><p>Let <var>list</var> be the result of <a>constructing the entry list</a> for
    <var>form</var>.<p></li>
 
-   <li><p>If <var>list</var> is null, <a>throw</a> an "{{IllegalStateError!!exception}}"
+   <li><p>If <var>list</var> is null, <a>throw</a> an "{{InvalidStateError!!exception}}"
    {{DOMException}}.</p></li>
 
    <li><p>Set <var>fd</var>'s <a for=FormData>entry list</a> to <var>list</var>.</p></li>


### PR DESCRIPTION
…turns null.

This fixes a part of https://github.com/w3c/webcomponents/issues/187

HTML specification PR: https://github.com/whatwg/html/pull/4239
Test: https://github.com/web-platform-tests/wpt/pull/14637


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/231.html" title="Last updated on Jan 2, 2019, 10:55 AM UTC (b31ad45)">Preview</a> | <a href="https://whatpr.org/xhr/231/0d4253c...b31ad45.html" title="Last updated on Jan 2, 2019, 10:55 AM UTC (b31ad45)">Diff</a>