### PR TITLE
Use XMLHttpRequestBodyInit as defined in Fetch, in send.

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -203,7 +203,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
            attribute unsigned long timeout;
            attribute boolean withCredentials;
   [SameObject] readonly attribute XMLHttpRequestUpload upload;
-  void send(optional (Document or BodyInit)? body = null);
+  void send(optional (Document or XMLHttpRequestBodyInit)? body = null);
   void abort();
 
   // response
@@ -703,7 +703,7 @@ method must run these steps:
    <a for=string>converted</a>, and <a lt="UTF-8 encode">UTF-8 encoded</a>.
 
    <li><p>Otherwise, set <a>request body</a> and <var>extractedContentType</var> to the result of
-   <a for=BodyInit>extracting</a> <var>body</var>.
+   <a for=XMLHttpRequestBodyInit>extracting</a> <var>body</var>.
 
    <li>
     <p>If <a>author request headers</a> <a for="header list">contains</a>
@@ -2073,6 +2073,7 @@ Feras Moussa,
 Gideon Cohn,
 Glenn Adams,
 Gorm Haug Eriksen,
+Gregory Terzian,
 Håkon Wium Lie,
 Hallvord R. M. Steen,
 Henri Sivonen,

--- a/xhr.bs
+++ b/xhr.bs
@@ -703,7 +703,7 @@ method must run these steps:
    <a for=string>converted</a>, and <a lt="UTF-8 encode">UTF-8 encoded</a>.
 
    <li><p>Otherwise, set <a>request body</a> and <var>extractedContentType</var> to the result of
-   <a for=XMLHttpRequestBodyInit>extracting</a> <var>body</var>.
+   <a for=BodyInit>extracting</a> <var>body</var>.
 
    <li>
     <p>If <a>author request headers</a> <a for="header list">contains</a>


### PR DESCRIPTION
Following-up on https://github.com/whatwg/fetch/pull/1029.

FIX #277

<!--
Thank you for contributing to the XMLHttpRequest Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   
    Mozilla cc @annevk
    Google cc @yutakahirano

- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * There are various tests asserting for example that a locked or disturbed stream results in `send` throwing an error, so with this change the stream will be stringified so then I assume the `USVString` branch of https://fetch.spec.whatwg.org/#concept-bodyinit-extract will be hit, and `send` will not throw if the stream was locked or disturbed, so those tests will have to be re-written. I can do it as part of https://github.com/servo/servo/issues/26723
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1091120
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1643243
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=212731

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 4, 2020, 6:22 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fxhr%2F379930757c7286965af541f2e013342ad24776b5%2Fxhr.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20279)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/xhr%23279.)._
</details>
