### PR TITLE
Add link to declarative shadow dom opt-in

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1302,7 +1302,7 @@ not be web compatible.
    <a>document</a> that
    represents the result of parsing <var>xhr</var>'s <a>received bytes</a> following the rules set
    forth in the HTML Standard for an HTML parser with scripting disabled,
-   <a>a known definite encoding</a> <var>charset</var>, and <span>include shadow roots state</span>
+   <a>a known definite encoding</a> <var>charset</var>, and <a>include shadow roots state</a>
    set to "deny".
    [[!HTML]]
 
@@ -1988,6 +1988,7 @@ Mark Birbeck,
 Mark Nottingham,
 Mark S. Miller,
 Martin Hassman,
+Mason Freed,
 Mike Pennisi,
 Mohamed Zergaoui,
 Ms2ger,

--- a/xhr.bs
+++ b/xhr.bs
@@ -1300,9 +1300,10 @@ not be web compatible.
 
    <li><p>Let <var>document</var> be a
    <a>document</a> that
-   represents the result parsing <var>xhr</var>'s <a>received bytes</a> following the rules set
-   forth in the HTML Standard for an HTML parser with scripting disabled and
-   <a>a known definite encoding</a> <var>charset</var>.
+   represents the result of parsing <var>xhr</var>'s <a>received bytes</a> following the rules set
+   forth in the HTML Standard for an HTML parser with scripting disabled,
+   <a>a known definite encoding</a> <var>charset</var>, and <span>include shadow roots state</span>
+   set to "deny".
    [[!HTML]]
 
    <li><p>Flag <var>document</var> as an


### PR DESCRIPTION
This PR goes along with the two in [HTML](https://github.com/whatwg/html/pull/5465) and [DOM](https://github.com/whatwg/dom/pull/892) to add declarative Shadow DOM to the spec. This PR goes along with the discussion at [#912](https://github.com/whatwg/dom/issues/912), to opt-in to the fragment parser for declarative Shadow DOM.

- [ ] At least two implementers are interested (and none opposed):
   * This is implemented, behind a flag, in Chromium. Tracking bug is [here](https://crbug.com/1042130).
   * 
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * In WPT: https://wpt.fyi/results/shadow-dom/declarative?label=master&label=experimental&aligned&q=declarative
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
  *  Chrome: https://crbug.com/1042130
  * Firefox: None yet
  * Safari: None yet


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/300.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (0344579)">Preview</a> | <a href="https://whatpr.org/xhr/300/17980b7...0344579.html" title="Last updated on Jan 15, 2021, 7:39 AM UTC (0344579)">Diff</a>