### PR TITLE
Stop censoring responseURL's fragment

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1156,11 +1156,9 @@ sequence). Unless stated otherwise it is the empty byte sequence.
 
 <h4 id=the-responseurl-attribute>The <code>responseURL</code> attribute</h4>
 
-<p>The <dfn attribute for=XMLHttpRequest><code>responseURL</code></dfn> attribute
-must return the empty string if <a>response</a>'s
-<a for=response>url</a> is null and its
-<a lt="URL serializer">serialization</a> with the
-<i>exclude fragment flag</i> set otherwise.
+<p>The <dfn attribute for=XMLHttpRequest><code>responseURL</code></dfn> attribute's getter, when
+invoked, must return the empty string if <a>response</a>'s <a for=response>URL</a> is null and its
+<a lt="URL serializer">serialization</a> otherwise.
 
 
 <h4 id=the-status-attribute>The <code>status</code> attribute</h4>


### PR DESCRIPTION
See https://github.com/whatwg/fetch/issues/505.

Tests: ...

Corresponding Fetch PR: https://github.com/whatwg/fetch/pull/696.

<!--
Thank you for contributing to the XMLHttpRequest Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * …
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/303.html" title="Last updated on Dec 8, 2020, 10:11 PM UTC (2ac9f13)">Preview</a> | <a href="https://whatpr.org/xhr/303/b592bc3...2ac9f13.html" title="Last updated on Dec 8, 2020, 10:11 PM UTC (2ac9f13)">Diff</a>