### PR TITLE
Editorial: adopt Fetch's new approach to callbacks

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -756,8 +756,6 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <dd><a>This</a>'s <a>request body</a>.
    <dt><a for=request>client</a>
    <dd><a>This</a>'s <a>relevant settings object</a>.
-   <dt><a for=request>synchronous flag</a>
-   <dd>Set if <a>this</a>'s <a>synchronous flag</a> is set.
    <dt><a for=request>mode</a>
    <dd>"<code>cors</code>".
    <dt><a for=request>use-CORS-preflight flag</a>

--- a/xhr.bs
+++ b/xhr.bs
@@ -909,13 +909,16 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <var>processRequestEndOfBody</var>, and <a for=fetch><i>processResponse</i></a> set to
    <var>processResponse</var>.
 
+   <li><p>Let <var>now</var> be the present time.
+   <!-- Eventually this should use some kind of time standard. -->
+
    <li>
     <p>Run these steps <a>in parallel</a>:
 
     <ol>
      <li><p>Wait until either <var>req</var>'s <a for=request>done flag</a> is set or <a>this</a>'s
-     <a>timeout</a> is not 0 and <a>this</a>'s <a>timeout</a> milliseconds have passed since these
-     steps started.
+     <a>timeout</a> is not 0 and <a>this</a>'s <a>timeout</a> milliseconds have passed since
+     <var>now</var>.
 
      <li><p>If <var>req</var>'s <a for=request>done flag</a> is unset, then set <a>this</a>'s
      <a>timed out flag</a> and <a for=fetch>terminate</a> <a for=/>fetching</a>.

--- a/xhr.bs
+++ b/xhr.bs
@@ -794,27 +794,10 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <a><code>send()</code> flag</a> is unset, then return.
 
    <li>
-    <p><a for=/>Fetch</a> <var>req</var>.
-    Handle the <a>tasks</a>
-    <a lt="queue a task">queued</a> on the
-    <a>networking task source</a> per below.
-
-    <p>Run these steps <a>in parallel</a>:
+    <p>Let <var>processRequestBody</var>, given a <var>request</var>, be these steps:
 
     <ol>
-     <li><p>Wait until either <var>req</var>'s <a for=request>done flag</a> is set or <a>this</a>'s
-     <a>timeout</a> is not 0 and <a>this</a>'s <a>timeout</a> milliseconds have passed since these
-     steps started.
-
-     <li><p>If <var>req</var>'s <a for=request>done flag</a> is unset, then set <a>this</a>'s
-     <a>timed out flag</a> and <a for=fetch>terminate</a> <a for=/>fetching</a>.
-    </ol>
-
-    <p>To <a>process request body</a> for <var>request</var>, run these steps:
-
-    <ol>
-     <li><p>If not roughly 50ms have passed since these steps were last invoked,
-     terminate these steps.
+     <li><p>If not roughly 50ms have passed since these steps were last invoked, then return.
 
      <li><p>If <a>this</a>'s <a>upload listener flag</a> is set, then <a>fire a progress event</a>
      named <a event><code>progress</code></a> at <a>this</a>'s <a>upload object</a> with
@@ -825,12 +808,13 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
     <p class=note>These steps are only invoked when new bytes are transmitted.
 
-    <p>To <a>process request end-of-body</a> for <var>request</var>, run these steps:
+   <li>
+    <p>Let <var>processRequestEndOfBody</var>, given a <var>request</var>, be these steps:
 
     <ol>
      <li><p>Set <a>this</a>'s <a>upload complete flag</a>.
 
-     <li><p>If <a>this</a>'s <a>upload listener flag</a> is unset, then terminate these steps.
+     <li><p>If <a>this</a>'s <a>upload listener flag</a> is unset, then return.
 
      <li><p>Let <var>transmitted</var> be <var>request</var>'s
      <a for=request>body</a>'s
@@ -851,12 +835,14 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
     </ol>
     <!-- upload complete flag can never be set here I hope -->
 
-    <p>To <a>process response</a> for <var>response</var>, run these steps:
+   <li>
+    <p>Let <var>processResponse</var>, given a <var>response</var>, be these steps:
 
     <ol>
      <li><p>Set <a>this</a>'s <a for=XMLHttpRequest>response</a> to <var>response</var>.
 
-     <li><p><a>Handle errors</a> fo <a>this</a> and <var>response</var>.
+     <li><p><a>Handle errors</a> for <a>this</a> and <a>this</a>'s
+     <a for=XMLHttpRequest>response</a>.
 
      <li><p>If <a>this</a>'s <a for=XMLHttpRequest>response</a> is a <a>network error</a>, then
      return.
@@ -876,7 +862,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
       <a>this</a>'s <a for=XMLHttpRequest>response</a>'s <a for=response>body</a>'s
       <a for=body>stream</a>.
 
-      <p><span class="note no-backref">This operation will not throw an exception.</span>
+      <p class=note>This operation will not throw an exception.
 
      <li>
       <p>Let <var>readRequest</var> be the following <a>read request</a>:
@@ -887,8 +873,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
         <ol>
          <li><p>Append <var>chunk</var> to <a>this</a>'s <a>received bytes</a>.
 
-         <li><p>If not roughly 50ms have passed since these steps were last invoked, then abort
-         these steps.
+         <li><p>If not roughly 50ms have passed since these steps were last invoked, then return.
 
          <li><p>If <a>this</a>'s <a>state</a> is <i>headers received</i>, then set <a>this</a>'s
          <a>state</a> to <i>loading</i>.
@@ -920,6 +905,23 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
      <li><p><a for=ReadableStreamDefaultReader>Read a chunk</a> from <var>reader</var> given
      <var>readRequest</var>.
     </ol>
+
+   <li><p><a for=/>Fetch</a> <var>req</var> with <a for=fetch><i>processRequestBody</i></a> set to
+   <var>processRequestBody</var>, <a for=fetch><i>processRequestEndOfBody</i></a> set to
+   <var>processRequestEndOfBody</var>, and <a for=fetch><i>processResponse</i></a> set to
+   <var>processResponse</var>.
+
+   <li>
+    <p>Run these steps <a>in parallel</a>:
+
+    <ol>
+     <li><p>Wait until either <var>req</var>'s <a for=request>done flag</a> is set or <a>this</a>'s
+     <a>timeout</a> is not 0 and <a>this</a>'s <a>timeout</a> milliseconds have passed since these
+     steps started.
+
+     <li><p>If <var>req</var>'s <a for=request>done flag</a> is unset, then set <a>this</a>'s
+     <a>timed out flag</a> and <a for=fetch>terminate</a> <a for=/>fetching</a>.
+    </ol>
   </ol>
 
  <li>
@@ -930,13 +932,31 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    is not <a>allowed to use</a> the "<code><a>sync-xhr</a></code>" feature, then run
    <a>handle response end-of-body</a> for <a>this</a> and a <a>network error</a>, and then return.
 
-   <li>
-    <p>Let <var>response</var> be the result of
-    <a for=/>fetching</a> <var>req</var>.
+   <li><p>Let <var>response</var> be a <a for=/>network error</a>.
 
-    <p>If <a>this</a>'s <a>timeout</a> is not 0, then set <a>this</a>'s <a>timed out flag</a> and
-    <a for=fetch>terminate</a> <a for=/>fetching</a> if it has not returned within <a>this</a>'s
-    <a>timeout</a> milliseconds.
+   <li><p>Let <var>processedResponse</var> be false.
+
+   <li>
+    <p>Let <var>processResponse</var>, given a <var>fetchResponse</var>, be these steps:
+
+    <ol>
+     <li><p>Set <var>response</var> to <var>fetchResponse</var>.
+
+     <li><p>Set <var>processedResponse</var> to true.
+    </ol>
+
+   <li><p><a for=/>Fetch</a> <var>req</var> with <a for=fetch><i>processResponse</i></a>
+   set to <var>processResponse</var> and <a for=fetch><i>useParallelQueue</i></a> set to true.
+
+   <li><p>Let <var>now</var> be the present time.
+   <!-- Eventually this should use some kind of time standard. -->
+
+   <li><p><a>Pause</a> until either <var>processedResponse</var> is true or <a>this</a>'s
+   <a>timeout</a> is not 0 and <a>this</a>'s <a>timeout</a> milliseconds have passed since
+   <var>now</var>.
+
+   <li><p>If <var>processedResponse</var> is false, then set <a>this</a>'s <a>timed out flag</a> and
+   <a for=fetch>terminate</a> <a for=/>fetching</a>.
 
    <li><p>If <var>response</var>'s <a for=response>body</a> is null, then run
    <a>handle response end-of-body</a> for <a>this</a> and <var>response</var>, and then return.
@@ -945,12 +965,12 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
     <p>Let <var>reader</var> be the result of <a for=ReadableStream>getting a reader</a> for
     <var>response</var>'s <a for=response>body</a>'s <a for=body>stream</a>.
 
-    <p><span class="note no-backref">This operation will not throw an exception.</span>
+    <p class=note>This operation will not throw an exception.
 
    <li><p>Let <var>promise</var> be the result of
    <a for=ReadableStreamDefaultReader>reading all bytes</a> from <var>reader</var>.
 
-   <li><p>Wait for <var>promise</var> to be fulfilled or rejected.
+   <li><p><a>Pause</a> until <var>promise</var> is fulfilled or rejected.
 
    <li><p>If <var>promise</var> is fulfilled with <var>bytes</var>, then append <var>bytes</var>
    to <a>this</a>'s <a>received bytes</a>.


### PR DESCRIPTION
See https://github.com/whatwg/fetch/pull/1165 for context.

@domenic so it seems XHR does all the awkward ways of reading a response body without helper. Lots of technical debt came with the introduction of streams to fetch. I didn't try to touch that here and instead focused purely on adopting the new callback approach, which does seem a lot cleaner in terms of what things get to run concurrently and such, but that does seem like an obvious thing to try to tackle next.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/311.html" title="Last updated on Feb 15, 2021, 6:36 AM UTC (0afb2ba)">Preview</a> | <a href="https://whatpr.org/xhr/311/8088cc5...0afb2ba.html" title="Last updated on Feb 15, 2021, 6:36 AM UTC (0afb2ba)">Diff</a>