### PR TITLE
Use extract a length from Fetch

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -786,8 +786,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <li><p>Let <var>uploadedBytesLength</var> be 0.
 
    <li><p>Let <var>totalUploadedBytesLength</var> be <var>req</var>'s <a for=request>body</a>'s
-   <a for=body>length</a>, if <var>req</var>'s <a for=request>body</a>'s <a for=body>length</a> is
-   non-null; otherwise 0.
+   <a for=body>length</a>, if <var>req</var>'s <a for=request>body</a> is non-null; otherwise 0.
 
    <li><p>If <a>this</a>'s <a>upload complete flag</a> is unset and <a>this</a>'s
    <a>upload listener flag</a> is set, then <a>fire a progress event</a> named

--- a/xhr.bs
+++ b/xhr.bs
@@ -783,15 +783,17 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <li><p><a>Fire a progress event</a> named <a event><code>loadstart</code></a> at <a>this</a>
    with 0 and 0.
 
-   <li><p>Let <var>uploadedBytesLength</var> be 0.
+   <li><p>Let <var>requestBodyTransmitted</var> be 0.
 
-   <li><p>Let <var>totalUploadedBytesLength</var> be <var>req</var>'s <a for=request>body</a>'s
+   <li><p>Let <var>requestBodyLength</var> be <var>req</var>'s <a for=request>body</a>'s
    <a for=body>length</a>, if <var>req</var>'s <a for=request>body</a> is non-null; otherwise 0.
+
+   <li><p>Assert: <var>requestBodyLength</var> is an integer.
 
    <li><p>If <a>this</a>'s <a>upload complete flag</a> is unset and <a>this</a>'s
    <a>upload listener flag</a> is set, then <a>fire a progress event</a> named
    <a event><code>loadstart</code></a> at <a>this</a>'s <a>upload object</a> with
-   <var>uploadedBytesLength</var> and <var>totalUploadedBytesLength</var>.
+   <var>requestBodyTransmitted</var> and <var>requestBodyLength</var>.
 
    <li><p>If <a>this</a>'s <a>state</a> is not <i>opened</i> or <a>this</a>'s
    <a><code>send()</code> flag</a> is unset, then return.
@@ -800,13 +802,13 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
     <p>Let <var>processRequestBody</var>, given a <var>bytesLength</var>, be these steps:
 
     <ol>
-     <li><p>Increase <var>uploadedBytesLength</var> by <var>bytesLength</var>.
+     <li><p>Increase <var>requestBodyTransmitted</var> by <var>bytesLength</var>.
 
      <li><p>If not roughly 50ms have passed since these steps were last invoked, then return.
 
      <li><p>If <a>this</a>'s <a>upload listener flag</a> is set, then <a>fire a progress event</a>
      named <a event><code>progress</code></a> at <a>this</a>'s <a>upload object</a> with
-     <var>uploadedBytesLength</var> and <var>totalUploadedBytesLength</var>.
+     <var>requestBodyTransmitted</var> and <var>requestBodyLength</var>.
      <!-- upload complete flag can never be set here I hope -->
     </ol>
 
@@ -821,16 +823,13 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
      <li><p>If <a>this</a>'s <a>upload listener flag</a> is unset, then return.
 
      <li><p><a>Fire a progress event</a> named <a event><code>progress</code></a> at <a>this</a>'s
-     <a>upload object</a> with <var>uploadedBytesLength</var> and
-     <var>totalUploadedBytesLength</var>.
+     <a>upload object</a> with <var>requestBodyTransmitted</var> and <var>requestBodyLength</var>.
 
      <li><p><a>Fire a progress event</a> named <a event><code>load</code></a> at <a>this</a>'s
-     <a>upload object</a> with <var>uploadedBytesLength</var> and
-     <var>totalUploadedBytesLength</var>.
+     <a>upload object</a> with <var>requestBodyTransmitted</var> and <var>requestBodyLength</var>.
 
      <li><p><a>Fire a progress event</a> named <a event><code>loadend</code></a> at <a>this</a>'s
-     <a>upload object</a> with <var>uploadedBytesLength</var> and
-     <var>totalUploadedBytesLength</var>.
+     <a>upload object</a> with <var>requestBodyTransmitted</var> and <var>requestBodyLength</var>.
     </ol>
     <!-- upload complete flag can never be set here I hope -->
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -783,15 +783,19 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <li><p><a>Fire a progress event</a> named <a event><code>loadstart</code></a> at <a>this</a>
    with 0 and 0.
 
+   <li><p>Let <var>uploadedBytesLength</var> be 0.
+
+   <li><p>Let <var>totalUploadedBytesLength</var> be <var>req</var>'s <a for=request>body</a>'s
+   <a for=body>length</a>, if <var>req</var>'s <a for=request>body</a>'s <a for=body>length</a> is
+   non-null; otherwise 0.
+
    <li><p>If <a>this</a>'s <a>upload complete flag</a> is unset and <a>this</a>'s
    <a>upload listener flag</a> is set, then <a>fire a progress event</a> named
-   <a event><code>loadstart</code></a> at <a>this</a>'s <a>upload object</a> with 0 and
-   <var>req</var>'s <a for=request>body</a>'s <a>total bytes</a>.
+   <a event><code>loadstart</code></a> at <a>this</a>'s <a>upload object</a> with
+   <var>uploadedBytesLength</var> and <var>totalUploadedBytesLength</var>.
 
    <li><p>If <a>this</a>'s <a>state</a> is not <i>opened</i> or <a>this</a>'s
    <a><code>send()</code> flag</a> is unset, then return.
-
-   <li><p>Let <var>uploadedBytesLength</var> be 0.
 
    <li>
     <p>Let <var>processRequestBody</var>, given a <var>bytesLength</var>, be these steps:
@@ -803,8 +807,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
      <li><p>If <a>this</a>'s <a>upload listener flag</a> is set, then <a>fire a progress event</a>
      named <a event><code>progress</code></a> at <a>this</a>'s <a>upload object</a> with
-     <var>uploadedBytesLength</var> and <var>req</var>'s <a for=request>body</a>'s
-     <a>total bytes</a>.
+     <var>uploadedBytesLength</var> and <var>totalUploadedBytesLength</var>.
      <!-- upload complete flag can never be set here I hope -->
     </ol>
 
@@ -818,18 +821,17 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
      <li><p>If <a>this</a>'s <a>upload listener flag</a> is unset, then return.
 
-     <li><p>Let <var>length</var> be <var>req</var>'s
-     <a for=request>body</a>'s
-     <a>total bytes</a>.
-
      <li><p><a>Fire a progress event</a> named <a event><code>progress</code></a> at <a>this</a>'s
-     <a>upload object</a> with <var>uploadedBytesLength</var> and <var>length</var>.
+     <a>upload object</a> with <var>uploadedBytesLength</var> and
+     <var>totalUploadedBytesLength</var>.
 
      <li><p><a>Fire a progress event</a> named <a event><code>load</code></a> at <a>this</a>'s
-     <a>upload object</a> with <var>uploadedBytesLength</var> and <var>length</var>.
+     <a>upload object</a> with <var>uploadedBytesLength</var> and
+     <var>totalUploadedBytesLength</var>.
 
      <li><p><a>Fire a progress event</a> named <a event><code>loadend</code></a> at <a>this</a>'s
-     <a>upload object</a> with <var>uploadedBytesLength</var> and <var>length</var>.
+     <a>upload object</a> with <var>uploadedBytesLength</var> and
+     <var>totalUploadedBytesLength</var>.
     </ol>
     <!-- upload complete flag can never be set here I hope -->
 
@@ -853,6 +855,11 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
      <li><p>If <a>this</a>'s <a for=XMLHttpRequest>response</a>'s <a for=response>body</a> is null,
      then run <a>handle response end-of-body</a> for <a>this</a> and return.
 
+     <li><p>Let <var>length</var> be the result of <a for="header list">extracting a length</a> from
+     <a>this</a>'s <a for=XMLHttpRequest>response</a>'s <a for=response>header list</a>.
+
+     <li><p>If <var>length</var> is not an integer, then set it to 0.
+
      <li>
       <p>Let <var>processBodyChunk</var> given <var>bytes</var> be these steps:
 
@@ -872,8 +879,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
        <li><p><a>Fire a progress event</a> named <a event><code>progress</code></a> at <a>this</a>
        with <a>this</a>'s <a>received bytes</a>'s <a for="byte sequence">length</a> and
-       <a>this</a>'s <a for=XMLHttpRequest>response</a>'s <a for=response>body</a>'s
-       <a>total bytes</a>.
+       <var>length</var>.
       </ol>
 
      <li><p>Let <var>processEndOfBody</var> be this step: run <a>handle response end-of-body</a> for
@@ -968,8 +974,10 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <li><p>Let <var>transmitted</var> be <var>xhr</var>'s <a>received bytes</a>'s
  <a for="byte sequence">length</a>.
 
- <li><p>Let <var>length</var> be <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s
- <a for=response>body</a>'s <a for=body>total bytes</a>.
+ <li><p>Let <var>length</var> be the result of <a for="header list">extracting a length</a> from
+ <a>this</a>'s <a for=XMLHttpRequest>response</a>'s <a for=response>header list</a>.
+
+ <li><p>If <var>length</var> is not an integer, then set it to 0.
 
  <li><p>If <var>xhr</var>'s <a>synchronous flag</a> is unset, then <a>fire a progress event</a>
  named <a event><code>progress</code></a> at <var>xhr</var> with <var>transmitted</var> and


### PR DESCRIPTION
The only information browsers use for progress events for responses is the Content-Length header.

Align on that and only use body's length concept for uploads.

Tests: web-platform-tests/wpt#27837.

Fetch PRs: whatwg/fetch#1183 & whatwg/fetch#1184.

- [x] At least two implementers are interested (and none opposed):
   * See https://github.com/whatwg/fetch/pull/1184.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * See above.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * See https://github.com/whatwg/fetch/pull/1184.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/317.html" title="Last updated on Mar 11, 2021, 11:34 AM UTC (7f29c9a)">Preview</a> | <a href="https://whatpr.org/xhr/317/231e282...7f29c9a.html" title="Last updated on Mar 11, 2021, 11:34 AM UTC (7f29c9a)">Diff</a>