### PR TITLE
Resource Timing integration

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1007,9 +1007,16 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <a for=response>aborted flag</a> is set, run the <a>request error steps</a> for <var>xhr</var>,
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
- <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
- <a for=/>network error</a>, run the <a>request error steps</a> for <var>xhr</var>,
- <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
+ <li>
+  <p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
+  <a for=/>network error</a>, then:
+
+  <ol>
+   <li><p><a for=/>Report timing</a> for <var>xhr</var>.
+
+   <li><p>Run the <a>request error steps</a> for <var>xhr</var>,
+   <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
+  </ol>
 </ol>
 
 <p>The <dfn>request error steps</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
@@ -1021,8 +1028,6 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <li><p>Unset <var>xhr</var>'s <a><code>send()</code> flag</a>.
 
  <li><p>Set <var>xhr</var>'s <a for=XMLHttpRequest>response</a> to a <a>network error</a>.
-
- <li><p><a for=/>Report timing</a> for <var>xhr</var>.
 
  <li><p>If <var>xhr</var>'s <a>synchronous flag</a> is set, then <a>throw</a> <var>exception</var>.
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -1009,11 +1009,7 @@ and "xmlhttprequest".
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
- <a for=/>network error</a>, then perform the following steps:
- <ol>
-  <li><p><a for=/>Report timing</a> for <var>xhr</var>.
-
-  <li><p>Run the <a>request error steps</a> for <var>xhr</var>,
+ <a for=/>network error</a>, then run the <a>request error steps</a> for <var>xhr</var>,
   <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
  </ol>
 </ol>
@@ -1023,6 +1019,8 @@ and "xmlhttprequest".
 
 <ol>
  <li><p>Set <var>xhr</var>'s <a>state</a> to <i>done</i>.
+
+ <li><p><a for=/>Report timing</a> for <var>xhr</var>.
 
  <li><p>Unset <var>xhr</var>'s <a><code>send()</code> flag</a>.
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -1011,7 +1011,6 @@ and "xmlhttprequest".
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
  <a for=/>network error</a>, then run the <a>request error steps</a> for <var>xhr</var>,
  <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
- </ol>
 </ol>
 
 <p>The <dfn>request error steps</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,

--- a/xhr.bs
+++ b/xhr.bs
@@ -954,6 +954,11 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
   </ol>
 </ol>
 
+<p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
+<a href="https://github.com/whatwg/fetch/pull/1185">finalize and report timing</a> for
+<var>xhr</var>'s <a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>
+and "xmlhttprequest".
+
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
 {{XMLHttpRequest}} object <var>xhr</var>, run these steps:
 
@@ -962,6 +967,8 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
  <li><p>If <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a <a>network error</a>, then
  return.
+
+ <li><p><a for=/>Report timing</a> for <var>xhr</var>.
 
  <li><p>Let <var>transmitted</var> be <var>xhr</var>'s <a>received bytes</a>'s
  <a for="byte sequence">length</a>.
@@ -1002,8 +1009,13 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
- <a for=/>network error</a>, run the <a>request error steps</a> for <var>xhr</var>,
- <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
+ <a for=/>network error</a>, then perform the following steps:
+ <ol>
+  <li><p><a for=/>Report timing</a> for <var>xhr</var>.
+
+  <li><p>Run the <a>request error steps</a> for <var>xhr</var>,
+  <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
+ </ol>
 </ol>
 
 <p>The <dfn>request error steps</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,

--- a/xhr.bs
+++ b/xhr.bs
@@ -954,10 +954,9 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
   </ol>
 </ol>
 
-<p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object
-<var>xhr</var>, <a for=/>finalize and report timing</a> for <var>xhr</var>'s
-<a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>, and
-"<code>xmlhttprequest</code>".
+<p>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
+<a for=/>finalize and report timing</a> for <var>xhr</var>'s <a for=XMLHttpRequest>response</a>,
+<var>xhr</var>'s <a>relevant global object</a>, and "<code>xmlhttprequest</code>".
 
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
 {{XMLHttpRequest}} object <var>xhr</var>, run these steps:

--- a/xhr.bs
+++ b/xhr.bs
@@ -955,7 +955,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 </ol>
 
 <p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
-<a href="https://github.com/whatwg/fetch/pull/1185">finalize and report timing</a> for
+<a for=/>finalize and report timing</a> for
 <var>xhr</var>'s <a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>,
 and "<code>xmlhttprequest</code>".
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -1008,7 +1008,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
  <li>
-  <p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
+  <p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a
   <a for=/>network error</a>, then:
 
   <ol>

--- a/xhr.bs
+++ b/xhr.bs
@@ -955,7 +955,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 </ol>
 
 <p>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
-<a for=/>finalize and report timing</a> for <var>xhr</var>'s <a for=XMLHttpRequest>response</a>,
+<a for=/>finalize and report timing</a> with <var>xhr</var>'s <a for=XMLHttpRequest>response</a>,
 <var>xhr</var>'s <a>relevant global object</a>, and "<code>xmlhttprequest</code>".
 
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an

--- a/xhr.bs
+++ b/xhr.bs
@@ -1009,7 +1009,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
- <a for=/>network error</a>, then run the <a>request error steps</a> for <var>xhr</var>,
+ <a for=/>network error</a>, run the <a>request error steps</a> for <var>xhr</var>,
  <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
 </ol>
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -956,7 +956,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
 <p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
 <a href="https://github.com/whatwg/fetch/pull/1185">finalize and report timing</a> for
-<var>xhr</var>'s <a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>
+<var>xhr</var>'s <a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>,
 and "xmlhttprequest".
 
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
@@ -1010,7 +1010,7 @@ and "xmlhttprequest".
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s is a
  <a for=/>network error</a>, then run the <a>request error steps</a> for <var>xhr</var>,
-  <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
+ <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
  </ol>
 </ol>
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -957,7 +957,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 <p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
 <a href="https://github.com/whatwg/fetch/pull/1185">finalize and report timing</a> for
 <var>xhr</var>'s <a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>,
-and "xmlhttprequest".
+and "<code>xmlhttprequest</code>".
 
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
 {{XMLHttpRequest}} object <var>xhr</var>, run these steps:

--- a/xhr.bs
+++ b/xhr.bs
@@ -1018,11 +1018,11 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 <ol>
  <li><p>Set <var>xhr</var>'s <a>state</a> to <i>done</i>.
 
- <li><p><a for=/>Report timing</a> for <var>xhr</var>.
-
  <li><p>Unset <var>xhr</var>'s <a><code>send()</code> flag</a>.
 
  <li><p>Set <var>xhr</var>'s <a for=XMLHttpRequest>response</a> to a <a>network error</a>.
+
+ <li><p><a for=/>Report timing</a> for <var>xhr</var>.
 
  <li><p>If <var>xhr</var>'s <a>synchronous flag</a> is set, then <a>throw</a> <var>exception</var>.
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -954,10 +954,10 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
   </ol>
 </ol>
 
-<p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
-<a for=/>finalize and report timing</a> for
-<var>xhr</var>'s <a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>,
-and "<code>xmlhttprequest</code>".
+<p id=report-xhr-timing>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object
+<var>xhr</var>, <a for=/>finalize and report timing</a> for <var>xhr</var>'s
+<a for=XMLHttpRequest>response</a>, <var>xhr</var>'s <a>relevant global object</a>, and
+"<code>xmlhttprequest</code>".
 
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
 {{XMLHttpRequest}} object <var>xhr</var>, run these steps:


### PR DESCRIPTION
When response is a network error or body is fully read,
finalize and report the response.

Depends on https://github.com/whatwg/fetch/pull/1185

See:
https://github.com/w3c/resource-timing/pull/261
and https://github.com/w3c/resource-timing/issues/252


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/319.html" title="Last updated on Dec 14, 2021, 7:52 AM UTC (0b6b341)">Preview</a> | <a href="https://whatpr.org/xhr/319/7647033...0b6b341.html" title="Last updated on Dec 14, 2021, 7:52 AM UTC (0b6b341)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/319.html" title="Last updated on Feb 11, 2022, 12:44 PM UTC (37ebd4b)">Preview</a> | <a href="https://whatpr.org/xhr/319/7647033...37ebd4b.html" title="Last updated on Feb 11, 2022, 12:44 PM UTC (37ebd4b)">Diff</a>