### PR TITLE
Editorial: Refactor for auto-reporting timing from fetch

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -963,7 +963,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <a for="fetch controller">terminate</a> <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a>.
 
    <li><p>Call <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a>'s
-   <a for="fetch controller">report timing steps</a> given the <a>current global object</a>.
+   <a for="fetch controller">report timing</a> given the <a>current global object</a>.
 
    <li><p>Run <a>handle response end-of-body</a> for <a>this</a>.
   </ol>

--- a/xhr.bs
+++ b/xhr.bs
@@ -964,9 +964,9 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
   </ol>
 </ol>
 
-<p>To <dfn>report timing</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,
-<a for=/>finalize and report timing</a> with <var>xhr</var>'s <a for=XMLHttpRequest>response</a>,
-<var>xhr</var>'s <a>relevant global object</a>, and "<code>xmlhttprequest</code>".
+<p>To <dfn>conclude</dfn> an {{XMLHttpRequest}} object <var>xhr</var>,
+<a for="fetch controller">conclude</a> <var>xhr</var>'s <a for=XMLHttpRequest>fetch controller</a>,
+given "<code>xmlhttprequest</code>" and <var>xhr</var>'s <a>relevant global object</a>.
 
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
 {{XMLHttpRequest}} object <var>xhr</var>, run these steps:
@@ -977,7 +977,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <li><p>If <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a <a>network error</a>, then
  return.
 
- <li><p><a for=/>Report timing</a> for <var>xhr</var>.
+ <li><p><a for=/>Conclude</a> <var>xhr</var>.
 
  <li><p>Let <var>transmitted</var> be <var>xhr</var>'s <a>received bytes</a>'s
  <a for="byte sequence">length</a>.
@@ -1022,7 +1022,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
   <a for=/>network error</a>, then:
 
   <ol>
-   <li><p><a for=/>Report timing</a> for <var>xhr</var>.
+   <li><p><a for=/>Conclude</a> <var>xhr</var>.
 
    <li><p>Run the <a>request error steps</a> for <var>xhr</var>,
    <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.

--- a/xhr.bs
+++ b/xhr.bs
@@ -962,6 +962,9 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <li><p>If <var>processedResponse</var> is false, then set <a>this</a>'s <a>timed out flag</a> and
    <a for="fetch controller">terminate</a> <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a>.
 
+   <li><p>Call <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a>'s
+   <a for="fetch controller">report timing steps</a> given the <a>current global object</a>.
+
    <li><p>Run <a>handle response end-of-body</a> for <a>this</a>.
   </ol>
 </ol>

--- a/xhr.bs
+++ b/xhr.bs
@@ -962,8 +962,8 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <li><p>If <var>processedResponse</var> is false, then set <a>this</a>'s <a>timed out flag</a> and
    <a for="fetch controller">terminate</a> <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a>.
 
-   <li><p>Call <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a>'s
-   <a for="fetch controller">report timing</a> given the <a>current global object</a>.
+   <li><p><a for="fetch controller">Report timing</a> for <a>this</a>'s
+   <a for=XMLHttpRequest>fetch controller</a> given the <a>current global object</a>.
 
    <li><p>Run <a>handle response end-of-body</a> for <a>this</a>.
   </ol>

--- a/xhr.bs
+++ b/xhr.bs
@@ -769,7 +769,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    otherwise "<code>same-origin</code>".
    <dt><a for=request>use-URL-credentials flag</a>
    <dd>Set if <a>this</a>'s <a>request URL</a> <a>includes credentials</a>.
-   <dt><a for=request>initiator</a>
+   <dt><a for=request>initiator type</a>
    <dd>"<code>xmlhttprequest</code>".
   </dl>
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -769,6 +769,8 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    otherwise "<code>same-origin</code>".
    <dt><a for=request>use-URL-credentials flag</a>
    <dd>Set if <a>this</a>'s <a>request URL</a> <a>includes credentials</a>.
+   <dt><a for=request>initiator</a>
+   <dd>"<code>xmlhttprequest</code>".
   </dl>
 
  <li><p>Unset <a>this</a>'s <a>upload complete flag</a>.
@@ -903,8 +905,6 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
    <li><p>Set <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a> to the result of
    <a for=/ lt=fetch>fetching</a> <var>req</var> with
-   <a for=fetch><i>timingGlobal</i></a> set to "<code>client</code>",
-   <a for=fetch><i>initiatorType</i></a> set to "<code>xmlhttprequest</code>",
    <a for=fetch><i>processRequestBodyChunkLength</i></a> set to
    <var>processRequestBodyChunkLength</var>, <a for=fetch><i>processRequestEndOfBody</i></a> set to
    <var>processRequestEndOfBody</var>, and <a for=fetch><i>processResponse</i></a> set to
@@ -1014,7 +1014,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a
- <a for=/>network error</a>, thenr run the <a>request error steps</a> for <var>xhr</var>,
+ <a for=/>network error</a>, then run the <a>request error steps</a> for <var>xhr</var>,
  <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
 </ol>
 

--- a/xhr.bs
+++ b/xhr.bs
@@ -903,6 +903,8 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
 
    <li><p>Set <a>this</a>'s <a for=XMLHttpRequest>fetch controller</a> to the result of
    <a for=/ lt=fetch>fetching</a> <var>req</var> with
+   <a for=fetch><i>timingGlobal</i></a> set to "<code>client</code>",
+   <a for=fetch><i>initiatorType</i></a> set to "<code>xmlhttprequest</code>",
    <a for=fetch><i>processRequestBodyChunkLength</i></a> set to
    <var>processRequestBodyChunkLength</var>, <a for=fetch><i>processRequestEndOfBody</i></a> set to
    <var>processRequestEndOfBody</var>, and <a for=fetch><i>processResponse</i></a> set to
@@ -964,10 +966,6 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
   </ol>
 </ol>
 
-<p>To <dfn>conclude</dfn> an {{XMLHttpRequest}} object <var>xhr</var>,
-<a for="fetch controller">conclude</a> <var>xhr</var>'s <a for=XMLHttpRequest>fetch controller</a>,
-given "<code>xmlhttprequest</code>" and <var>xhr</var>'s <a>relevant global object</a>.
-
 <p id=handle-response-end-of-file>To <dfn>handle response end-of-body</dfn> for an
 {{XMLHttpRequest}} object <var>xhr</var>, run these steps:
 
@@ -976,8 +974,6 @@ given "<code>xmlhttprequest</code>" and <var>xhr</var>'s <a>relevant global obje
 
  <li><p>If <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a <a>network error</a>, then
  return.
-
- <li><p><a for=/>Conclude</a> <var>xhr</var>.
 
  <li><p>Let <var>transmitted</var> be <var>xhr</var>'s <a>received bytes</a>'s
  <a for="byte sequence">length</a>.
@@ -1017,16 +1013,9 @@ given "<code>xmlhttprequest</code>" and <var>xhr</var>'s <a>relevant global obje
  <a for=response>aborted flag</a> is set, run the <a>request error steps</a> for <var>xhr</var>,
  <a event><code>abort</code></a>, and "{{AbortError!!exception}}" {{DOMException}}.
 
- <li>
-  <p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a
-  <a for=/>network error</a>, then:
-
-  <ol>
-   <li><p><a for=/>Conclude</a> <var>xhr</var>.
-
-   <li><p>Run the <a>request error steps</a> for <var>xhr</var>,
-   <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
-  </ol>
+ <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a
+ <a for=/>network error</a>, thenr run the <a>request error steps</a> for <var>xhr</var>,
+ <a event><code>error</code></a>, and "{{NetworkError!!exception}}" {{DOMException}}.
 </ol>
 
 <p>The <dfn>request error steps</dfn> for an {{XMLHttpRequest}} object <var>xhr</var>,


### PR DESCRIPTION
Depends on https://github.com/whatwg/fetch/pull/1413

This clarifies that a resource timing entry is always for a
fetch and not for a request or response.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/347.html" title="Last updated on Aug 15, 2022, 7:35 AM UTC (f0c21bc)">Preview</a> | <a href="https://whatpr.org/xhr/347/9d481f8...f0c21bc.html" title="Last updated on Aug 15, 2022, 7:35 AM UTC (f0c21bc)">Diff</a>