### PR TITLE
Editorial: use fetch's new "body with type"

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -685,8 +685,20 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <var>body</var>, <a lt="fragment serializing algorithm">serialized</a>,
    <a for=string>converted</a>, and <a lt="UTF-8 encode">UTF-8 encoded</a>.
 
-   <li><p>Otherwise, set <a>this</a>'s <a>request body</a> and <var>extractedContentType</var> to
-   the result of <a for=BodyInit lt="safely extract">safely extracting</a> <var>body</var>.
+   <li>
+    <p>Otherwise:
+
+    <ol>
+     <li><p>Let <var>bodyWithType</var> be the result of
+     <a for=BodyInit lt="safely extract">safely extracting</a> <var>body</var>.
+
+     <li><p>Set <a>this</a>'s <a>request body</a> to <var>bodyWithType</var>'s
+     <a for="body with type">body</a>.
+
+     <li><p>Set <var>extractedContentType</var> to <var>bodyWithType</var>'s
+     <a for="body with type">type</a>.
+    </ol>
+   </li>
 
    <li><p>Let <var>originalAuthorContentType</var> be the result of <a for="header list">getting</a>
    `<code>Content-Type</code>` from <a>this</a>'s <a>author request headers</a>.


### PR DESCRIPTION
See https://github.com/whatwg/fetch/pull/1439.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/349.html" title="Last updated on May 11, 2022, 12:39 PM UTC (75e7977)">Preview</a> | <a href="https://whatpr.org/xhr/349/9d481f8...75e7977.html" title="Last updated on May 11, 2022, 12:39 PM UTC (75e7977)">Diff</a>