### PR TITLE
Editorial: Use the term "author request headers" consistently

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -369,7 +369,7 @@ cell in the first column is <a>this</a>'s <a>state</a>:
   <td><i>opened</i>
   <td><dfn const for=XMLHttpRequest><code>OPENED</code></dfn> (numeric value 1)
   <td>The <a method for=XMLHttpRequest lt="open(method, url)"><code>open()</code></a> method has
-  been successfully invoked. During this state request headers can be set using
+  been successfully invoked. During this state author request headers can be set using
   <a><code>setRequestHeader()</code></a> and the fetch can be initiated using the
   <a><code>send()</code></a> method.
  <tr>


### PR DESCRIPTION
<!--
Thank you for contributing to the XMLHttpRequest Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

The spec uses the term "author request headers" everywhere except in the description of the `OPENED` state in https://xhr.spec.whatwg.org/#states. This commit fixes this inconsistency.

I think this qualifies as an Editorial change, but I am unsure. Please advise is this is incorrect.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/354.html" title="Last updated on Aug 26, 2022, 8:51 PM UTC (ecd6963)">Preview</a> | <a href="https://whatpr.org/xhr/354/fb328af...ecd6963.html" title="Last updated on Aug 26, 2022, 8:51 PM UTC (ecd6963)">Diff</a>