### PR TITLE
Update link for fragment serialization algorithm

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -15,11 +15,6 @@ spec:webdriver-bidi; type:dfn; text:event
 spec:fetch; type:dfn; for:/; text:credentials
 </pre>
 
-<pre class=anchors>
-urlPrefix: https://w3c.github.io/DOM-Parsing/; spec: dom-parsing
-    type: dfn; text: fragment serializing algorithm; url: dfn-fragment-serializing-algorithm
-</pre>
-
 
 
 <h2 id=introduction>Introduction</h2>
@@ -686,7 +681,7 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
    <li><p>Let <var>extractedContentType</var> be null.
 
    <li><p>If <var>body</var> is a {{Document}}, then set <a>this</a>'s <a>request body</a> to
-   <var>body</var>, <a lt="fragment serializing algorithm">serialized</a>,
+   <var>body</var>, <a lt="fragment serializing algorithm steps">serialized</a>,
    <a for=string>converted</a>, and <a lt="UTF-8 encode">UTF-8 encoded</a>.
 
    <li>

--- a/xhr.bs
+++ b/xhr.bs
@@ -1023,9 +1023,9 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  for <var>xhr</var>, <a event><code>timeout</code></a>, and "{{TimeoutError!!exception}}"
  {{DOMException}}.
 
- <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s <a for=response>aborted
- flag</a> is set, run the <a>request error steps</a> for <var>xhr</var>, <a event
- for=XMLHttpRequestEventTarget><code>abort</code></a>, and "{{AbortError!!exception}}"
+ <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s
+ <a for=response>aborted flag</a> is set, run the <a>request error steps</a> for <var>xhr</var>,
+ <a event for=XMLHttpRequestEventTarget><code>abort</code></a>, and "{{AbortError!!exception}}"
  {{DOMException}}.
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a
@@ -1088,9 +1088,10 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <li><p><a for="fetch controller">Abort</a> <a>this</a>'s
  <a for=XMLHttpRequest>fetch controller</a>.
 
- <li><p>If <a>this</a>'s <a>state</a> is <i>opened</i> with <a>this</a>'s <a><code>send()</code>
- flag</a> set, <i>headers received</i>, or <i>loading</i>, then run the <a>request error steps</a>
- for <a>this</a> and <a event for=XMLHttpRequestEventTarget><code>abort</code></a>.
+ <li><p>If <a>this</a>'s <a>state</a> is <i>opened</i> with <a>this</a>'s
+ <a><code>send()</code> flag</a> set, <i>headers received</i>, or <i>loading</i>, then run the
+ <a>request error steps</a> for <a>this</a> and
+ <a event for=XMLHttpRequestEventTarget><code>abort</code></a>.
 
  <li>
   <p>If <a>this</a>'s <a>state</a> is <i>done</i>, then set <a>this</a>'s <a>state</a> to

--- a/xhr.bs
+++ b/xhr.bs
@@ -1023,9 +1023,9 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  for <var>xhr</var>, <a event><code>timeout</code></a>, and "{{TimeoutError!!exception}}"
  {{DOMException}}.
 
- <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s
- <a for=response>aborted flag</a> is set, run the <a>request error steps</a> for <var>xhr</var>,
- <a event for=XMLHttpRequest><code>abort</code></a>, and "{{AbortError!!exception}}"
+ <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a>'s <a for=response>aborted
+ flag</a> is set, run the <a>request error steps</a> for <var>xhr</var>, <a event
+ for=XMLHttpRequestEventTarget><code>abort</code></a>, and "{{AbortError!!exception}}"
  {{DOMException}}.
 
  <li><p>Otherwise, if <var>xhr</var>'s <a for=XMLHttpRequest>response</a> is a
@@ -1088,9 +1088,9 @@ return <a>this</a>'s <a>cross-origin credentials</a>.
  <li><p><a for="fetch controller">Abort</a> <a>this</a>'s
  <a for=XMLHttpRequest>fetch controller</a>.
 
- <li><p>If <a>this</a>'s <a>state</a> is <i>opened</i> with <a>this</a>'s
- <a><code>send()</code> flag</a> set, <i>headers received</i>, or <i>loading</i>, then run the
- <a>request error steps</a> for <a>this</a> and <a event for=XMLHttpRequest><code>abort</code></a>.
+ <li><p>If <a>this</a>'s <a>state</a> is <i>opened</i> with <a>this</a>'s <a><code>send()</code>
+ flag</a> set, <i>headers received</i>, or <i>loading</i>, then run the <a>request error steps</a>
+ for <a>this</a> and <a event for=XMLHttpRequestEventTarget><code>abort</code></a>.
 
  <li>
   <p>If <a>this</a>'s <a>state</a> is <i>done</i>, then set <a>this</a>'s <a>state</a> to


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/10497 which fixes the algorithm definition to take a Document


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/390.html" title="Last updated on Aug 12, 2024, 1:12 PM UTC (bbd013d)">Preview</a> | <a href="https://whatpr.org/xhr/390/fd438ec...bbd013d.html" title="Last updated on Aug 12, 2024, 1:12 PM UTC (bbd013d)">Diff</a>