### PR TITLE
Allow doubles for ProgressEvent's loaded and total

### DIFF
--- a/xhr.bs
+++ b/xhr.bs
@@ -1753,14 +1753,14 @@ interface ProgressEvent : Event {
   constructor(DOMString type, optional ProgressEventInit eventInitDict = {});
 
   readonly attribute boolean lengthComputable;
-  readonly attribute unsigned long long loaded;
-  readonly attribute unsigned long long total;
+  readonly attribute double loaded;
+  readonly attribute double total;
 };
 
 dictionary ProgressEventInit : EventInit {
   boolean lengthComputable = false;
-  unsigned long long loaded = 0;
-  unsigned long long total = 0;
+  double loaded = 0;
+  double total = 0;
 };
 </pre>
 


### PR DESCRIPTION
This allows specifications to use ProgressEvents while not necessarily giving away the exact number of bytes, for example by using numbers between 0 and 1. See discussion in https://github.com/webmachinelearning/writing-assistance-apis/issues/15 for the concrete use case.

- [x] At least two implementers are interested (and none opposed):
   * Chromium is interested
   * Per comments in this thread, WebKit and Gecko are supportive
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/50714
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/381969448
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1943649
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=288688
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/641
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

---

I wanted to get this PR up to judge implementer interest. It would be a decent bit cleaner if we all agreed this was reasonable and merged the change now, instead of having to float a patch in the relevant specs and thus causing all the databases to have two definitions of `ProgressEvent`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/xhr/394.html" title="Last updated on Feb 27, 2025, 5:18 AM UTC (5b4e883)">Preview</a> | <a href="https://whatpr.org/xhr/394/150a3b8...5b4e883.html" title="Last updated on Feb 27, 2025, 5:18 AM UTC (5b4e883)">Diff</a>