### PR TITLE
Reset request body when open() is called

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 2
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.14"
     - run: pip install bikeshed && bikeshed update
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy

--- a/xhr.bs
+++ b/xhr.bs
@@ -488,13 +488,13 @@ method steps are:
 
   <ul>
    <li><p>Unset <a>this</a>'s <a><code>send()</code> flag</a>.
-   <li><p>Unset <a>this</a>'s <a>upload listener flag</a>.
-   <li><p>Set <a>this</a>'s <a>request body</a> to null.
    <li><p>Set <a>this</a>'s <a>request method</a> to <var>method</var>.
    <li><p>Set <a>this</a>'s <a>request URL</a> to <var>parsedURL</var>.
+   <li><p><a for=list>Empty</a> <a>this</a>'s <a>author request headers</a>.
+   <li><p>Set <a>this</a>'s <a>request body</a> to null.
    <li><p>Set <a>this</a>'s <a>synchronous flag</a> if <var>async</var> is false; otherwise unset
    <a>this</a>'s <a>synchronous flag</a>.
-   <li><p><a for=list>Empty</a> <a>this</a>'s <a>author request headers</a>.
+   <li><p>Unset <a>this</a>'s <a>upload listener flag</a>.
    <li><p>Set <a>this</a>'s <a for=XMLHttpRequest>response</a> to a <a>network error</a>.
    <li><p>Set <a>this</a>'s <a>received bytes</a> to the empty byte sequence.
    <li><p>Set <a>this</a>'s <a>response object</a> to null.

--- a/xhr.bs
+++ b/xhr.bs
@@ -489,6 +489,7 @@ method steps are:
   <ul>
    <li><p>Unset <a>this</a>'s <a><code>send()</code> flag</a>.
    <li><p>Unset <a>this</a>'s <a>upload listener flag</a>.
+   <li><p>Set <a>this</a>'s <a>request body</a> to null.
    <li><p>Set <a>this</a>'s <a>request method</a> to <var>method</var>.
    <li><p>Set <a>this</a>'s <a>request URL</a> to <var>parsedURL</var>.
    <li><p>Set <a>this</a>'s <a>synchronous flag</a> if <var>async</var> is false; otherwise unset


### PR DESCRIPTION
Otherwise the request body can leak into subsequent requests on the same XHR object.

- [x] At least two implementers are interested (and none opposed):
   * Chrome/Webkit/Gecko already implemented
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * This was found through the following WPT test https://github.com/web-platform-tests/wpt/blob/master/cors/simple-requests.htm
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
